### PR TITLE
Add multi-select support for info rectangles

### DIFF
--- a/app.py
+++ b/app.py
@@ -668,21 +668,39 @@ class InteractiveToolApp(QMainWindow):
         self.update_properties_panel()
 
     def on_scene_selection_changed(self):
-        if not hasattr(self, 'scene') or not self.scene: return
+        if not hasattr(self, 'scene') or not self.scene:
+            return
+
         selected_items = self.scene.selectedItems()
-        newly_selected_item = selected_items[0] if selected_items else None
-        if self.selected_item is not newly_selected_item:
-            if self.selected_item and isinstance(self.selected_item, InfoRectangleItem):
-                self.selected_item.update_appearance(False, self.current_mode == "view")
-            self.selected_item = newly_selected_item
-            if self.selected_item and isinstance(self.selected_item, InfoRectangleItem):
-                self.selected_item.update_appearance(True, self.current_mode == "view")
+
+        # Update appearance for all info rectangles based on selection state
+        for item in self.scene.items():
+            if isinstance(item, InfoRectangleItem):
+                item.update_appearance(item in selected_items, self.current_mode == "view")
+
+        # Track the last selected item for the properties panel
+        self.selected_item = selected_items[-1] if selected_items else None
         self.update_properties_panel()
 
     def on_graphics_item_selected(self, graphics_item):
         if self.current_mode == "view":
             if hasattr(self, 'scene') and self.scene: self.scene.clearSelection()
             self.selected_item = None
+            self.update_properties_panel()
+            return
+
+        ctrl_pressed = QApplication.keyboardModifiers() & Qt.ControlModifier
+
+        if ctrl_pressed:
+            # Toggle selection without affecting other selected items
+            if isinstance(graphics_item, InfoRectangleItem):
+                graphics_item.update_appearance(graphics_item.isSelected(), self.current_mode == "view")
+
+            if graphics_item.isSelected():
+                self.selected_item = graphics_item
+            else:
+                selected_items = self.scene.selectedItems() if self.scene else []
+                self.selected_item = selected_items[-1] if selected_items else None
             self.update_properties_panel()
             return
         

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1687,3 +1687,30 @@ def test_font_color_change_updates_item_and_ui(mock_get_color, base_app_fixture,
     if not app._does_current_rect_match_default_style(selected_item_config) and \
        not app._find_matching_style_name(selected_item_config):
         assert app.rect_style_combo.currentText() == "Custom"
+
+
+def test_multi_select_with_ctrl(monkeypatch, base_app_fixture):
+    app = base_app_fixture
+    app.config['info_rectangles'] = [
+        {"id": "rect1", "text": "", "width": 40, "height": 20, "center_x": 30, "center_y": 30, "z_index": 1},
+        {"id": "rect2", "text": "", "width": 40, "height": 20, "center_x": 100, "center_y": 30, "z_index": 2},
+    ]
+
+    app.scene.clear()
+    app.item_map.clear()
+    app.render_canvas_from_config()
+
+    rect1 = app.item_map['rect1']
+    rect2 = app.item_map['rect2']
+
+    # Click first rectangle normally
+    app.on_graphics_item_selected(rect1)
+    assert rect1.isSelected() and not rect2.isSelected()
+
+    # Ctrl-click second rectangle
+    monkeypatch.setattr(QApplication, 'keyboardModifiers', lambda: Qt.ControlModifier)
+    rect2.setSelected(True)
+    app.on_graphics_item_selected(rect2)
+    monkeypatch.setattr(QApplication, 'keyboardModifiers', lambda: Qt.NoModifier)
+
+    assert rect1.isSelected() and rect2.isSelected()


### PR DESCRIPTION
## Summary
- allow multi-selection of info rectangles when Ctrl is pressed
- update appearance for all selected rectangles
- add unit test ensuring Ctrl-click keeps previous selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ae7364de8832787048e3b95e49788