### PR TITLE
Refactor keyboard handling into InputHandler

### DIFF
--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -1,0 +1,66 @@
+# New InputHandler for keyboard shortcuts and layering operations
+from PyQt5.QtWidgets import QApplication, QLineEdit, QTextEdit, QSpinBox, QDoubleSpinBox
+from PyQt5.QtCore import Qt
+
+from . import utils
+
+
+class InputHandler:
+    """Handles keyboard shortcuts and z-order actions for the main application."""
+
+    def __init__(self, app):
+        self.app = app
+
+    # -- Keyboard Shortcut Handling -------------------------------------
+    def handle_key_press(self, event):
+        """Process key press events. Returns True if the event was handled."""
+        focused_widget = QApplication.focusWidget()
+        is_input_focused = isinstance(
+            focused_widget, (QLineEdit, QTextEdit, QSpinBox, QDoubleSpinBox)
+        )
+
+        if event.modifiers() == Qt.ControlModifier:
+            if event.key() == Qt.Key_C:
+                if (
+                    self.app.current_mode == "edit"
+                    and not is_input_focused
+                    and self.app.item_operations.copy_selected_item_to_clipboard()
+                ):
+                    event.accept()
+                    return True
+            elif event.key() == Qt.Key_V:
+                if self.app.current_mode == "edit" and not is_input_focused:
+                    if self.app.item_operations.paste_item_from_clipboard():
+                        event.accept()
+                        return True
+        elif event.key() in (Qt.Key_Delete, Qt.Key_Backspace):
+            if (
+                self.app.current_mode == "edit"
+                and not is_input_focused
+                and self.app.item_operations.delete_selected_item_on_canvas()
+            ):
+                event.accept()
+                return True
+        event.ignore()
+        return False
+
+    # -- Z-Order Manipulation ------------------------------------------
+    def bring_to_front_selected(self):
+        if self.app.selected_item:
+            utils.bring_to_front(self.app.selected_item)
+            self.app.save_config()
+
+    def send_to_back_selected(self):
+        if self.app.selected_item:
+            utils.send_to_back(self.app.selected_item)
+            self.app.save_config()
+
+    def bring_forward_selected(self):
+        if self.app.selected_item:
+            utils.bring_forward(self.app.selected_item)
+            self.app.save_config()
+
+    def send_backward_selected(self):
+        if self.app.selected_item:
+            utils.send_backward(self.app.selected_item)
+            self.app.save_config()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -477,100 +477,6 @@ def test_update_selected_rect_dimensions(base_app_fixture, monkeypatch):
     selected_rect_item.update_geometry_from_config.assert_called_once()
 
 
-# --- Tests for Z-Order Manipulation --- #
-
-@patch('app.utils.bring_to_front')
-def test_bring_to_front_action(mock_util_bring_to_front, base_app_fixture, monkeypatch):
-    app = base_app_fixture
-    app.selected_item = MagicMock()
-    monkeypatch.setattr(app, 'save_config', MagicMock())
-    app.bring_to_front()
-    mock_util_bring_to_front.assert_called_once_with(app.selected_item)
-    app.save_config.assert_called_once()
-
-@patch('app.utils.send_to_back')
-def test_send_to_back_action(mock_util_send_to_back, base_app_fixture, monkeypatch):
-    app = base_app_fixture
-    app.selected_item = MagicMock()
-    monkeypatch.setattr(app, 'save_config', MagicMock())
-    app.send_to_back()
-    mock_util_send_to_back.assert_called_once_with(app.selected_item)
-    app.save_config.assert_called_once()
-
-@patch('app.utils.bring_forward')
-def test_bring_forward_action(mock_util_bring_forward, base_app_fixture, monkeypatch):
-    app = base_app_fixture
-    app.selected_item = MagicMock()
-    monkeypatch.setattr(app, 'save_config', MagicMock())
-    app.bring_forward()
-    mock_util_bring_forward.assert_called_once_with(app.selected_item)
-    app.save_config.assert_called_once()
-
-@patch('app.utils.send_backward')
-def test_send_backward_action(mock_util_send_backward, base_app_fixture, monkeypatch):
-    app = base_app_fixture
-    app.selected_item = MagicMock()
-    monkeypatch.setattr(app, 'save_config', MagicMock())
-    app.send_backward()
-    mock_util_send_backward.assert_called_once_with(app.selected_item)
-    app.save_config.assert_called_once()
-
-
-def test_z_order_actions_no_selected_item(base_app_fixture, monkeypatch):
-    app = base_app_fixture
-    app.selected_item = None
-    mock_btf = MagicMock()
-    monkeypatch.setattr('src.utils.bring_to_front', mock_btf)
-    mock_stb = MagicMock()
-    monkeypatch.setattr('src.utils.send_to_back', mock_stb)
-    mock_bf = MagicMock()
-    monkeypatch.setattr('src.utils.bring_forward', mock_bf)
-    mock_sb = MagicMock()
-    monkeypatch.setattr('src.utils.send_backward', mock_sb)
-    mock_save = MagicMock()
-    monkeypatch.setattr(app, 'save_config', mock_save)
-    app.bring_to_front()
-    app.send_to_back()
-    app.bring_forward()
-    app.send_backward()
-    mock_btf.assert_not_called()
-    mock_stb.assert_not_called()
-    mock_bf.assert_not_called()
-    mock_sb.assert_not_called()
-    mock_save.assert_not_called()
-
-
-# --- Tests for Keyboard Shortcuts (those remaining in app.py or general handling) --- #
-
-def create_key_event(key, modifiers=Qt.NoModifier, text=""):
-    return QKeyEvent(QKeyEvent.KeyPress, key, modifiers, text)
-
-@patch('app.QApplication.focusWidget')
-def test_key_press_shortcuts_wrong_mode(mock_focus_widget, base_app_fixture):
-    app = base_app_fixture
-    mock_focus_widget.return_value = app.view
-    app.current_mode = "view"
-    app.selected_item = MagicMock(spec=InfoRectangleItem)
-    app.clipboard_data = None
-    # Mock the item_operations methods directly to check if they are NOT called
-    app.item_operations.copy_selected_item_to_clipboard = MagicMock(return_value=False)
-    app.item_operations.paste_item_from_clipboard = MagicMock(return_value=False)
-    app.item_operations.delete_selected_item_on_canvas = MagicMock(return_value=False)
-
-    event_copy = create_key_event(Qt.Key_C, modifiers=Qt.ControlModifier)
-    app.keyPressEvent(event_copy)
-    app.item_operations.copy_selected_item_to_clipboard.assert_not_called()
-    assert not event_copy.isAccepted()
-
-    event_paste = create_key_event(Qt.Key_V, modifiers=Qt.ControlModifier)
-    app.keyPressEvent(event_paste)
-    app.item_operations.paste_item_from_clipboard.assert_not_called()
-    assert not event_paste.isAccepted()
-
-    event_delete = create_key_event(Qt.Key_Delete)
-    app.keyPressEvent(event_delete)
-    app.item_operations.delete_selected_item_on_canvas.assert_not_called()
-    assert not event_delete.isAccepted()
 
 
 # --- Tests for Application State Reset --- #
@@ -635,34 +541,6 @@ def test_handle_deleted_other_project(base_app_fixture, monkeypatch):
     app._handle_deleted_current_project("some_other_deleted_project")
     mock_reset_method.assert_not_called()
 
-@patch('app.QApplication.focusWidget')
-def test_key_press_shortcuts_input_focused(mock_focus_widget, base_app_fixture):
-    app = base_app_fixture
-    mock_focus_widget.return_value = MagicMock(spec=['__class__', '__name__'])
-    from PyQt5.QtWidgets import QLineEdit # Local import
-    mock_focus_widget.return_value.__class__ = QLineEdit
-    app.current_mode = "edit"
-    app.selected_item = MagicMock(spec=InfoRectangleItem)
-    app.clipboard_data = None
-    # Mock item_operations methods
-    app.item_operations.copy_selected_item_to_clipboard = MagicMock(return_value=False)
-    app.item_operations.paste_item_from_clipboard = MagicMock(return_value=False)
-    app.item_operations.delete_selected_item_on_canvas = MagicMock(return_value=False)
-
-    event_copy = create_key_event(Qt.Key_C, modifiers=Qt.ControlModifier)
-    app.keyPressEvent(event_copy)
-    app.item_operations.copy_selected_item_to_clipboard.assert_not_called()
-    assert not event_copy.isAccepted()
-
-    event_paste = create_key_event(Qt.Key_V, modifiers=Qt.ControlModifier)
-    app.keyPressEvent(event_paste)
-    app.item_operations.paste_item_from_clipboard.assert_not_called()
-    assert not event_paste.isAccepted()
-
-    event_delete = create_key_event(Qt.Key_Delete)
-    app.keyPressEvent(event_delete)
-    app.item_operations.delete_selected_item_on_canvas.assert_not_called()
-    assert not event_delete.isAccepted()
 
 
 # --- Tests for Image Management (Should be empty or only non-movable tests) --- #

--- a/tests/test_input_handler.py
+++ b/tests/test_input_handler.py
@@ -1,0 +1,141 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QKeyEvent
+from PyQt5.QtWidgets import QLineEdit
+
+from src.input_handler import InputHandler
+from src.info_rectangle_item import InfoRectangleItem
+
+
+def create_key_event(key, modifiers=Qt.NoModifier, text=""):
+    return QKeyEvent(QKeyEvent.KeyPress, key, modifiers, text)
+
+
+# --- Z-Order Manipulation Tests ---
+@patch('src.utils.bring_to_front')
+def test_bring_to_front_action(mock_btf, base_app_fixture, monkeypatch):
+    app = base_app_fixture
+    handler = app.input_handler
+    app.selected_item = MagicMock()
+    monkeypatch.setattr(app, 'save_config', MagicMock())
+    handler.bring_to_front_selected()
+    mock_btf.assert_called_once_with(app.selected_item)
+    app.save_config.assert_called_once()
+
+
+@patch('src.utils.send_to_back')
+def test_send_to_back_action(mock_stb, base_app_fixture, monkeypatch):
+    app = base_app_fixture
+    handler = app.input_handler
+    app.selected_item = MagicMock()
+    monkeypatch.setattr(app, 'save_config', MagicMock())
+    handler.send_to_back_selected()
+    mock_stb.assert_called_once_with(app.selected_item)
+    app.save_config.assert_called_once()
+
+
+@patch('src.utils.bring_forward')
+def test_bring_forward_action(mock_bf, base_app_fixture, monkeypatch):
+    app = base_app_fixture
+    handler = app.input_handler
+    app.selected_item = MagicMock()
+    monkeypatch.setattr(app, 'save_config', MagicMock())
+    handler.bring_forward_selected()
+    mock_bf.assert_called_once_with(app.selected_item)
+    app.save_config.assert_called_once()
+
+
+@patch('src.utils.send_backward')
+def test_send_backward_action(mock_sb, base_app_fixture, monkeypatch):
+    app = base_app_fixture
+    handler = app.input_handler
+    app.selected_item = MagicMock()
+    monkeypatch.setattr(app, 'save_config', MagicMock())
+    handler.send_backward_selected()
+    mock_sb.assert_called_once_with(app.selected_item)
+    app.save_config.assert_called_once()
+
+
+def test_z_order_actions_no_selected_item(base_app_fixture, monkeypatch):
+    app = base_app_fixture
+    handler = app.input_handler
+    app.selected_item = None
+    mock_btf = MagicMock()
+    monkeypatch.setattr('src.utils.bring_to_front', mock_btf)
+    mock_stb = MagicMock()
+    monkeypatch.setattr('src.utils.send_to_back', mock_stb)
+    mock_bf = MagicMock()
+    monkeypatch.setattr('src.utils.bring_forward', mock_bf)
+    mock_sb = MagicMock()
+    monkeypatch.setattr('src.utils.send_backward', mock_sb)
+    mock_save = MagicMock()
+    monkeypatch.setattr(app, 'save_config', mock_save)
+    handler.bring_to_front_selected()
+    handler.send_to_back_selected()
+    handler.bring_forward_selected()
+    handler.send_backward_selected()
+    mock_btf.assert_not_called()
+    mock_stb.assert_not_called()
+    mock_bf.assert_not_called()
+    mock_sb.assert_not_called()
+    mock_save.assert_not_called()
+
+
+# --- Keyboard Shortcut Tests ---
+@patch('src.input_handler.QApplication.focusWidget')
+def test_key_press_shortcuts_wrong_mode(mock_focus_widget, base_app_fixture):
+    app = base_app_fixture
+    handler = app.input_handler
+    mock_focus_widget.return_value = app.view
+    app.current_mode = "view"
+    app.selected_item = MagicMock(spec=InfoRectangleItem)
+    app.clipboard_data = None
+    app.item_operations.copy_selected_item_to_clipboard = MagicMock(return_value=False)
+    app.item_operations.paste_item_from_clipboard = MagicMock(return_value=False)
+    app.item_operations.delete_selected_item_on_canvas = MagicMock(return_value=False)
+
+    event_copy = create_key_event(Qt.Key_C, modifiers=Qt.ControlModifier)
+    handled = handler.handle_key_press(event_copy)
+    app.item_operations.copy_selected_item_to_clipboard.assert_not_called()
+    assert not event_copy.isAccepted() and handled is False
+
+    event_paste = create_key_event(Qt.Key_V, modifiers=Qt.ControlModifier)
+    handled = handler.handle_key_press(event_paste)
+    app.item_operations.paste_item_from_clipboard.assert_not_called()
+    assert not event_paste.isAccepted() and handled is False
+
+    event_delete = create_key_event(Qt.Key_Delete)
+    handled = handler.handle_key_press(event_delete)
+    app.item_operations.delete_selected_item_on_canvas.assert_not_called()
+    assert not event_delete.isAccepted() and handled is False
+
+
+@patch('src.input_handler.QApplication.focusWidget')
+def test_key_press_shortcuts_input_focused(mock_focus_widget, base_app_fixture):
+    app = base_app_fixture
+    handler = app.input_handler
+    mock_focus_widget.return_value = MagicMock(spec=['__class__', '__name__'])
+    mock_focus_widget.return_value.__class__ = QLineEdit
+    app.current_mode = "edit"
+    app.selected_item = MagicMock(spec=InfoRectangleItem)
+    app.clipboard_data = None
+    app.item_operations.copy_selected_item_to_clipboard = MagicMock(return_value=False)
+    app.item_operations.paste_item_from_clipboard = MagicMock(return_value=False)
+    app.item_operations.delete_selected_item_on_canvas = MagicMock(return_value=False)
+
+    event_copy = create_key_event(Qt.Key_C, modifiers=Qt.ControlModifier)
+    handled = handler.handle_key_press(event_copy)
+    app.item_operations.copy_selected_item_to_clipboard.assert_not_called()
+    assert not event_copy.isAccepted() and handled is False
+
+    event_paste = create_key_event(Qt.Key_V, modifiers=Qt.ControlModifier)
+    handled = handler.handle_key_press(event_paste)
+    app.item_operations.paste_item_from_clipboard.assert_not_called()
+    assert not event_paste.isAccepted() and handled is False
+
+    event_delete = create_key_event(Qt.Key_Delete)
+    handled = handler.handle_key_press(event_delete)
+    app.item_operations.delete_selected_item_on_canvas.assert_not_called()
+    assert not event_delete.isAccepted() and handled is False


### PR DESCRIPTION
## Summary
- add `InputHandler` module to encapsulate keyboard shortcuts and z‑order actions
- delegate these features from `InteractiveToolApp`
- update tests accordingly and move related tests into `test_input_handler.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c3a79cd848327a9753f5a45a8ffd7