### PR TITLE
Refactor: Rename project to InfoCanvas and verify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-# Interactive Image Tool
+# InfoCanvas
+
+* [Basic Purpose](#basic-purpose)
+* [File Structure](#file-structure)
+* [Installation](#installation)
+* [Usage](#usage)
+* [Project Management](#project-management)
+* [Stopping the Application](#stopping-the-application)
+* [Running Tests](#running-tests)
 
 ## Basic Purpose
 
@@ -10,27 +18,48 @@ The project follows this basic structure:
 
 ```
 /interactive-image-tool/
-|-- app.py                 # Main Python PyQt5 application
+|-- .gitignore             # Specifies intentionally untracked files that Git should ignore
+|-- app.py                 # Main entry point for the PyQt5 application
 |-- requirements.txt       # Python package dependencies
 |-- README.md              # This file
-|-- /static/               # Root directory for project-specific files
+|-- /src/                  # Contains all core Python source code for the application
+|   |-- canvas_manager.py
+|   |-- draggable_image_item.py
+|   |-- exporter.py
+|   |-- info_rectangle_item.py
+|   |-- input_handler.py
+|   |-- item_operations.py
+|   |-- project_io.py
+|   |-- project_manager_dialog.py
+|   |-- text_style_manager.py
+|   |-- ui_builder.py
+|   |-- utils.py
+|-- /static/               # Root directory for project-specific files (created automatically if it doesn't exist)
 |   |-- /<project_name>/   # Folder for a specific project
 |   |   |-- config.json    # Stores background, image, and hotspot data for this project
 |   |   |-- /images/       # Stores images uploaded for this project
 |   |   |   |-- (uploaded images will appear here)
 |-- /doc/                  # Contains documentation like toolRequirements.md
 |   |-- toolRequirements.md
+|-- /tests/                # Contains test scripts for the application
+|   |-- __init__.py
+|   |-- conftest.py
+|   |-- test_app.py
+|   |-- (and other test_*.py files)
 ```
 
--   **`app.py`**: Contains the main PyQt5 application logic, including UI, event handling, and project management.
+-   **`.gitignore`**: Specifies intentionally untracked files that Git should ignore (e.g., `venv/`, `__pycache__/`).
+-   **`app.py`**: Main entry point for the PyQt5 application. It initializes and runs the application defined in the `src/` directory.
 -   **`requirements.txt`**: Lists the Python packages needed to run the application (e.g., PyQt5).
 -   **`README.md`**: This file.
--   **`static/`**: This directory serves as the root for storing all project-specific data.
+-   **`src/`**: This directory contains all the core Python source code for the application, organized into modules (e.g., `canvas_manager.py`, `ui_builder.py`, etc.).
+-   **`static/`**: This directory serves as the root for storing all project-specific data. It and its subdirectories are created automatically by the application if they don't already exist.
     -   **`/<project_name>/`**: Each sub-directory within `static/` represents an individual project.
         -   **`config.json`**: Located within each project's folder, this file stores the specific configuration for that project, including background settings, image details (paths, positions, scales), and info rectangle data.
         -   **`images/`**: Also within each project's folder, this sub-directory holds all images uploaded by the user for that particular project.
 -   **`doc/`**: Contains additional documentation for the project.
     -   **`toolRequirements.md`**: Describes the (original) requirements for the tool.
+-   **`tests/`**: This directory holds all the test scripts for the application, using `pytest`.
 
 ## Installation
 
@@ -97,7 +126,7 @@ The project follows this basic structure:
 
 ## Project Management
 
-This application supports managing multiple distinct interactive image projects. Each project has its own canvas, images, and hotspot configurations.
+This application supports managing multiple distinct InfoCanvas projects. Each project has its own canvas, images, and hotspot configurations.
 
 -   **Project Storage:**
     -   All projects are stored as subdirectories within the `static/` folder in the application's root directory.

--- a/app.py
+++ b/app.py
@@ -20,7 +20,7 @@ from src.text_style_manager import TextStyleManager
 from src.exporter import HtmlExporter # <--- NEW IMPORT
 from src.input_handler import InputHandler
 # --- Main Application Window ---
-class InteractiveToolApp(QMainWindow):
+class InfoCanvasApp(QMainWindow):
     def __init__(self):
         super().__init__()
         self.setGeometry(100, 100, 1200, 700)
@@ -59,9 +59,9 @@ class InteractiveToolApp(QMainWindow):
 
     def _update_window_title(self):
         if self.current_project_name:
-            self.setWindowTitle(f"PyQt5 Interactive Image Tool - {self.current_project_name}")
+            self.setWindowTitle(f"InfoCanvas - {self.current_project_name}")
         else:
-            self.setWindowTitle("PyQt5 Interactive Image Tool - No Project Loaded")
+            self.setWindowTitle("InfoCanvas - No Project Loaded")
 
     def _reset_application_to_no_project_state(self):
         """Resets the UI and internal state when no project is loaded or current is deleted."""
@@ -808,7 +808,7 @@ class InteractiveToolApp(QMainWindow):
 if __name__ == '__main__':
     app = QApplication.instance() or QApplication(sys.argv)
     
-    main_window = InteractiveToolApp()
+    main_window = InfoCanvasApp()
     if main_window.current_project_name: 
         main_window.show()
         sys.exit(app.exec_())

--- a/doc/toolRequirements.md
+++ b/doc/toolRequirements.md
@@ -1,4 +1,4 @@
-# Interactive Image Tool: Requirements & JSON Configuration
+# InfoCanvas: Requirements & JSON Configuration
 
 This document outlines the requirements for a web-based Python tool designed for creating interactive images with informational overlays. It also proposes a JSON format for storing the configuration data.
 

--- a/src/canvas_manager.py
+++ b/src/canvas_manager.py
@@ -9,7 +9,7 @@ from .info_rectangle_item import InfoRectangleItem
 
 
 class CanvasManager(QObject):
-    """Encapsulates QGraphicsScene related logic for InteractiveToolApp."""
+    """Encapsulates QGraphicsScene related logic for InfoCanvasApp."""
 
     selection_changed = pyqtSignal()
 

--- a/src/text_style_manager.py
+++ b/src/text_style_manager.py
@@ -12,7 +12,7 @@ class TextStyleManager:
         Initializes the TextStyleManager.
 
         Args:
-            app: The main InteractiveToolApp instance.
+            app: The main InfoCanvasApp instance.
         """
         self.app = app
 

--- a/src/ui_builder.py
+++ b/src/ui_builder.py
@@ -7,7 +7,7 @@ from PyQt5.QtGui import QColor, QBrush, QPainter
 from PyQt5.QtCore import Qt
 
 class UIBuilder:
-    """Builds the main UI for :class:`InteractiveToolApp`."""
+    """Builds the main UI for :class:`InfoCanvasApp`."""
 
     def __init__(self, app):
         self.app = app


### PR DESCRIPTION
- I renamed all instances of "Interactive Image Tool" to "InfoCanvas" in README.md.
- I verified that the README.md file structure section does not contain duplicate listings.
- I updated the project name in other files:
    - `app.py`: I changed the class name InteractiveToolApp to InfoCanvasApp and updated window titles.
    - `doc/toolRequirements.md`: I updated the title.
    - I updated docstrings in `src/canvas_manager.py`, `src/text_style_manager.py`, and `src/ui_builder.py` to refer to the new application class name.