### PR TITLE
Fix app close crash when selection active

### DIFF
--- a/src/canvas_manager.py
+++ b/src/canvas_manager.py
@@ -1,5 +1,6 @@
 import os
 from PyQt5.QtCore import QObject, pyqtSignal, Qt
+from PyQt5.sip import isdeleted
 from PyQt5.QtGui import QColor, QBrush, QPixmap, QTransform
 from PyQt5.QtWidgets import QGraphicsScene, QMessageBox, QApplication
 
@@ -112,7 +113,7 @@ class CanvasManager(QObject):
     # ---- Selection Handling -------------------------------------------
     def on_scene_selection_changed(self):
         app = self.app
-        if not self.scene:
+        if not self.scene or isdeleted(self.scene):
             app.chronologically_first_selected_item = None
             app.selected_item = None
             app.update_properties_panel()


### PR DESCRIPTION
## Summary
- protect CanvasManager from using a deleted `QGraphicsScene`
- ensure selectionChanged handler checks scene validity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce5582d848327bbe45ed8cdae4493