### PR TITLE
Remove font_style from defaults

### DIFF
--- a/app.py
+++ b/app.py
@@ -330,7 +330,7 @@ class InfoCanvasApp(QMainWindow):
 
             h_align = rect_conf.get('horizontal_alignment', default_text_config['horizontal_alignment'])
             v_align = rect_conf.get('vertical_alignment', default_text_config['vertical_alignment'])
-            font_style = rect_conf.get('font_style', default_text_config['font_style'])
+            font_style = rect_conf.get('font_style', default_text_config.get('font_style', 'normal'))
             font_size = str(rect_conf.get('font_size', default_text_config['font_size'])).replace("px", "")
 
             self.rect_h_align_combo.setCurrentText(h_align.capitalize())

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -93,7 +93,7 @@ class HtmlExporter:
             else: padding = padding_str
             h_align = rect_conf.get('horizontal_alignment', self.default_text_config['horizontal_alignment'])
             v_align = rect_conf.get('vertical_alignment', self.default_text_config['vertical_alignment'])
-            font_style_prop = rect_conf.get('font_style', self.default_text_config['font_style'])
+            font_style_prop = rect_conf.get('font_style', self.default_text_config.get('font_style', 'normal'))
             outer_style = f"position:absolute; left:{left}px; top:{top}px; width:{rect_width}px; height:{rect_height}px; display:flex; box-sizing: border-box;"
             if v_align == "top": outer_style += "align-items:flex-start;"
             elif v_align == "center" or v_align == "middle": outer_style += "align-items:center;"

--- a/src/info_rectangle_item.py
+++ b/src/info_rectangle_item.py
@@ -38,7 +38,7 @@ class InfoRectangleItem(QGraphicsObject):
         text_format_defaults = utils.get_default_config()["defaults"]["info_rectangle_text_display"]
         self.vertical_alignment = self.config_data.get('vertical_alignment', text_format_defaults['vertical_alignment'])
         self.horizontal_alignment = self.config_data.get('horizontal_alignment', text_format_defaults['horizontal_alignment'])
-        self.font_style = self.config_data.get('font_style', text_format_defaults['font_style'])
+        self.font_style = self.config_data.get('font_style', text_format_defaults.get('font_style', 'normal'))
 
         self.setFlags(QGraphicsItem.ItemIsSelectable |
                       QGraphicsItem.ItemIsMovable |
@@ -292,7 +292,7 @@ class InfoRectangleItem(QGraphicsObject):
 
         self.vertical_alignment = self._get_style_value('vertical_alignment', text_format_defaults['vertical_alignment'])
         self.horizontal_alignment = self._get_style_value('horizontal_alignment', text_format_defaults['horizontal_alignment'])
-        self.font_style = self._get_style_value('font_style', text_format_defaults['font_style'])
+        self.font_style = self._get_style_value('font_style', text_format_defaults.get('font_style', 'normal'))
         font_color = self._get_style_value('font_color', text_format_defaults['font_color'])
         font_size_str = self._get_style_value('font_size', text_format_defaults['font_size'])
 

--- a/src/text_style_manager.py
+++ b/src/text_style_manager.py
@@ -83,7 +83,7 @@ class TextStyleManager:
             "name": style_name,
             "font_color": item_config.get('font_color', default_display_conf['font_color']),
             "font_size": item_config.get('font_size', default_display_conf['font_size']),
-            "font_style": item_config.get('font_style', default_display_conf['font_style']),
+            "font_style": item_config.get('font_style', default_display_conf.get('font_style', 'normal')),
             "horizontal_alignment": item_config.get('horizontal_alignment', default_display_conf['horizontal_alignment']),
             "vertical_alignment": item_config.get('vertical_alignment', default_display_conf['vertical_alignment']),
             "padding": item_config.get('padding', default_display_conf['padding']),

--- a/src/utils.py
+++ b/src/utils.py
@@ -36,8 +36,7 @@ def get_default_config():
                 "box_width": 200,
                 "padding": "5px",
                 "vertical_alignment": "top",
-                "horizontal_alignment": "left",
-                "font_style": "normal"
+                "horizontal_alignment": "left"
             }
         },
         "text_styles": [],

--- a/tests/test_info_rectangle_item.py
+++ b/tests/test_info_rectangle_item.py
@@ -44,7 +44,7 @@ def create_item_with_scene(default_text_config_values, qtbot, mock_parent_window
             'font_color': default_text_config_values['font_color'], 'font_size': default_text_config_values['font_size'],
             'background_color': default_text_config_values['background_color'], 'padding': default_text_config_values['padding'],
             'vertical_alignment': default_text_config_values['vertical_alignment'],
-            'horizontal_alignment': default_text_config_values['horizontal_alignment'], 'font_style': default_text_config_values['font_style'],
+            'horizontal_alignment': default_text_config_values['horizontal_alignment'],
         }
         if custom_config:
             base_config.update(custom_config)
@@ -461,13 +461,10 @@ def test_apply_style_key_precedence(item_fixture, default_text_config_values):
 
     assert item.config_data['text'] == "Styled Text"
     assert item.config_data['font_size'] == "20px"
-    assert item.config_data['font_style'] == default_text_config_values['font_style']
+    assert 'font_style' not in item.config_data
     assert item.text_item.toPlainText() == "Styled Text"
     assert item.text_item.font().pointSize() == 20
-    if default_text_config_values['font_style'] == "normal":
-        assert not item.text_item.font().bold() and not item.text_item.font().italic()
-    elif default_text_config_values['font_style'] == "bold":
-        assert item.text_item.font().bold()
+    assert not item.text_item.font().bold() and not item.text_item.font().italic()
 
 def test_apply_style_emits_properties_changed(item_fixture):
     item = item_fixture


### PR DESCRIPTION
## Summary
- drop `font_style` from the default text display config
- handle missing `font_style` in application code
- adjust related tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ceb3af408832785fcc4731e9851c8