### PR TITLE
Improve view mode hover display for info rectangles

### DIFF
--- a/app.py
+++ b/app.py
@@ -216,10 +216,7 @@ class InfoCanvasApp(QMainWindow):
                     graphics_item.setCursor(Qt.CursorShape.PointingHandCursor if graphics_item.isEnabled() else Qt.CursorShape.ArrowCursor)
             else:
                 graphics_item.setCursor(Qt.CursorShape.ArrowCursor)
-                if isinstance(graphics_item, InfoRectangleItem):
-                    graphics_item.setToolTip(graphics_item.config_data.get('text', ''))
-                else:
-                    graphics_item.setToolTip('')
+                graphics_item.setToolTip('')
 
         if not is_edit_mode:
             if hasattr(self, 'scene') and self.scene: self.scene.clearSelection()

--- a/src/info_rectangle_item.py
+++ b/src/info_rectangle_item.py
@@ -118,10 +118,23 @@ class InfoRectangleItem(QGraphicsObject):
                 self.setCursor(QCursor(default_cursor_shape))
         super().hoverMoveEvent(event)
 
+    def hoverEnterEvent(self, event):
+        parent_win = None
+        if self.scene() and hasattr(self.scene(), 'parent_window'):
+            parent_win = self.scene().parent_window
+        if parent_win and parent_win.current_mode == "view":
+            self.text_item.setVisible(True)
+        super().hoverEnterEvent(event)
+
     def hoverLeaveEvent(self, event):
+        parent_win = None
+        if self.scene() and hasattr(self.scene(), 'parent_window'):
+            parent_win = self.scene().parent_window
+        if parent_win and parent_win.current_mode == "view":
+            self.text_item.setVisible(False)
         if not self._is_resizing:
             default_cursor_shape = Qt.ArrowCursor
-            if self.scene() and hasattr(self.scene(), 'parent_window') and self.scene().parent_window.current_mode == "edit" and (self.flags() & QGraphicsItem.ItemIsMovable):
+            if parent_win and parent_win.current_mode == "edit" and (self.flags() & QGraphicsItem.ItemIsMovable):
                 default_cursor_shape = Qt.PointingHandCursor
             self.setCursor(QCursor(default_cursor_shape))
         super().hoverLeaveEvent(event)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -326,7 +326,7 @@ def test_on_mode_changed(base_app_fixture, monkeypatch):
     mock_info_rect_item.update_appearance.assert_called_with(mock_info_rect_item.isSelected(), True)
     mock_image_item.setCursor.assert_called_with(Qt.ArrowCursor)
     mock_info_rect_item.setCursor.assert_called_with(Qt.ArrowCursor)
-    mock_info_rect_item.setToolTip.assert_called()
+    mock_info_rect_item.setToolTip.assert_called_with('')
 
     mock_image_item.reset_mock()
     mock_info_rect_item.reset_mock()

--- a/tests/test_info_rectangle_item.py
+++ b/tests/test_info_rectangle_item.py
@@ -500,3 +500,20 @@ def test_item_change_position_not_resizing(item_fixture):
     assert item.config_data['center_y'] == expected_cy
     assert item.config_data['center_x'] != initial_cx
     assert item.config_data['center_y'] != initial_cy
+
+
+def test_hover_enter_leave_view_mode_shows_text(create_item_with_scene):
+    item, scene, mock_parent_window = create_item_with_scene()
+    mock_parent_window.current_mode = "view"
+    item.update_appearance(False, True)
+    assert item.text_item.isVisible() is False
+
+    hover_pos = item.boundingRect().center()
+    event = create_mock_hover_event(hover_pos, scene_pos=item.mapToScene(hover_pos))
+    with patch.object(QGraphicsItem, 'hoverEnterEvent', Mock()):
+        item.hoverEnterEvent(event)
+    assert item.text_item.isVisible() is True
+
+    with patch.object(QGraphicsItem, 'hoverLeaveEvent', Mock()):
+        item.hoverLeaveEvent(event)
+    assert item.text_item.isVisible() is False


### PR DESCRIPTION
## Summary
- show info rectangle text when hovered in view mode
- hide it again on hover leave
- remove tooltip text from view mode
- update tests for hover behavior and tooltip clearing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d3e84e53c8327b20698761b7eee47