### PR TITLE
Add configuration undo stack and Ctrl+Z support

### DIFF
--- a/src/input_handler.py
+++ b/src/input_handler.py
@@ -33,6 +33,11 @@ class InputHandler:
                     if self.app.item_operations.paste_item_from_clipboard():
                         event.accept()
                         return True
+            elif event.key() == Qt.Key_Z:
+                if not is_input_focused:
+                    self.app.undo_last_action()
+                    event.accept()
+                    return True
         elif event.key() in (Qt.Key_Delete, Qt.Key_Backspace):
             if (
                 self.app.current_mode == "edit"


### PR DESCRIPTION
## Summary
- maintain a history of configuration snapshots in `InfoCanvasApp`
- push snapshots whenever `save_config` is called
- add `undo_last_action` to revert to previous config state
- hook Ctrl+Z to the undo action in `InputHandler`
- add unit tests for the Ctrl+Z behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d498b8830832791d2d9eaf6c4598d