### PR TITLE
Add hover toggle for info rectangles

### DIFF
--- a/app.py
+++ b/app.py
@@ -259,7 +259,10 @@ class InfoCanvasApp(QMainWindow):
             else:
                 graphics_item.setCursor(Qt.CursorShape.ArrowCursor)
                 if isinstance(graphics_item, InfoRectangleItem):
-                    graphics_item.setToolTip(graphics_item.config_data.get('text', ''))
+                    if graphics_item.config_data.get('show_on_hover', True):
+                        graphics_item.setToolTip(graphics_item.config_data.get('text', ''))
+                    else:
+                        graphics_item.setToolTip('')
                 else:
                     graphics_item.setToolTip('')
 
@@ -321,6 +324,9 @@ class InfoCanvasApp(QMainWindow):
             self.info_rect_text_input.setPlainText(rect_conf.get('text', ''))
             self.info_rect_width_input.setValue(int(rect_conf.get('width', 100)))
             self.info_rect_height_input.setValue(int(rect_conf.get('height', 50)))
+            self.rect_show_on_hover_checkbox.blockSignals(True)
+            self.rect_show_on_hover_checkbox.setChecked(rect_conf.get('show_on_hover', True))
+            self.rect_show_on_hover_checkbox.blockSignals(False)
 
             # Update new formatting controls
             self.rect_h_align_combo.blockSignals(True)
@@ -475,7 +481,7 @@ class InfoCanvasApp(QMainWindow):
                 self.selected_item.set_display_text(new_text) 
                 self.save_config() 
 
-    def update_selected_rect_dimensions(self): 
+    def update_selected_rect_dimensions(self):
         """Called when width/height spinboxes in the properties panel change."""
         if isinstance(self.selected_item, InfoRectangleItem):
             rect_conf = self.selected_item.config_data
@@ -486,6 +492,13 @@ class InfoCanvasApp(QMainWindow):
             rect_conf['height'] = max(self.selected_item.MIN_HEIGHT, new_height)
             
             self.selected_item.properties_changed.emit(self.selected_item)
+
+    def update_selected_rect_show_on_hover(self, state):
+        if isinstance(self.selected_item, InfoRectangleItem):
+            rect_conf = self.selected_item.config_data
+            rect_conf['show_on_hover'] = bool(state)
+            self.selected_item.update_appearance(self.selected_item.isSelected(), self.current_mode == "view")
+            self.save_config()
 
 
     def delete_selected_info_rect(self):

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -113,9 +113,12 @@ class HtmlExporter:
                 f"padding:{padding};", f"text-align:{h_align};"
             ]
             current_inner_style = "".join(inner_style_list)
-            text_content_div_style = current_inner_style + " display: none;"
+            show_on_hover = rect_conf.get('show_on_hover', True)
+            display_style = 'none' if show_on_hover else 'block'
+            text_content_div_style = current_inner_style + f" display: {display_style};"
+            data_attr = f"data-show-on-hover='{str(show_on_hover).lower()}'"
             lines.append(
-                f"<div class='hotspot info-rectangle-export' style='{outer_style}'>"
+                f"<div class='hotspot info-rectangle-export' {data_attr} style='{outer_style}'>"
                 f"<div class='text-content' style='{text_content_div_style}'>{text_content}</div></div>"
             )
         lines.extend([
@@ -123,8 +126,10 @@ class HtmlExporter:
             "document.querySelectorAll('.hotspot.info-rectangle-export').forEach(function(h){",
             "  var textContentDiv = h.querySelector('.text-content');",
             "  if (!textContentDiv) return;",
-            "  h.addEventListener('mouseenter', function(e){ textContentDiv.style.display = 'block'; });",
-            "  h.addEventListener('mouseleave', function(e){ textContentDiv.style.display = 'none'; });",
+            "  if (h.dataset.showOnHover !== 'false') {",
+            "    h.addEventListener('mouseenter', function(e){ textContentDiv.style.display = 'block'; });",
+            "    h.addEventListener('mouseleave', function(e){ textContentDiv.style.display = 'none'; });",
+            "  }",
             "});", "</script>", "</body></html>"
         ])
         return "\n".join(lines)

--- a/src/info_rectangle_item.py
+++ b/src/info_rectangle_item.py
@@ -29,6 +29,7 @@ class InfoRectangleItem(BaseDraggableItem):
     def __init__(self, rect_config, parent_item=None):
         super().__init__(parent_item)
         self.config_data = rect_config
+        self.config_data.setdefault('show_on_hover', True)
         self._style_config_ref = None
         self._w = self.config_data.get('width', 100)
         self._h = self.config_data.get('height', 50)
@@ -325,7 +326,7 @@ class InfoRectangleItem(BaseDraggableItem):
         if is_view_mode:
             self._pen = QPen(Qt.transparent)
             self._brush = QBrush(Qt.transparent)
-            self.text_item.setVisible(False)
+            self.text_item.setVisible(not self.config_data.get('show_on_hover', True))
         else:
             self.text_item.setVisible(True)
             if is_selected:

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -209,6 +209,7 @@ class ItemOperations:
             "width": default_display_conf.get("box_width", 150), # Use resolved default
             "height": 50, # Default height
             "text": "New Information",
+            "show_on_hover": True,
             "z_index": self._get_next_z_index(), # Local method
         }
 

--- a/src/ui_builder.py
+++ b/src/ui_builder.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import (
     QWidget, QDockWidget, QVBoxLayout, QHBoxLayout, QPushButton,
     QLabel, QComboBox, QSpinBox, QTextEdit, QAction, QGraphicsScene,
-    QGraphicsView, QDoubleSpinBox, QMessageBox, QStackedLayout
+    QGraphicsView, QDoubleSpinBox, QMessageBox, QStackedLayout, QCheckBox
 )
 try:
     from PyQt5.QtWebEngineWidgets import QWebEngineView
@@ -251,6 +251,10 @@ class UIBuilder:
         app.info_rect_height_input.valueChanged.connect(app.update_selected_rect_dimensions)
         rect_height_layout.addWidget(app.info_rect_height_input)
         rect_props_layout.addLayout(rect_height_layout)
+
+        app.rect_show_on_hover_checkbox = QCheckBox("Show text on hover only")
+        app.rect_show_on_hover_checkbox.stateChanged.connect(app.update_selected_rect_show_on_hover)
+        rect_props_layout.addWidget(app.rect_show_on_hover_checkbox)
 
         app.delete_info_rect_button = QPushButton("Delete Selected Info Rect")
         app.delete_info_rect_button.setStyleSheet("background-color: #dc3545; color: white;")

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -38,6 +38,7 @@ def test_export_to_html_writes_file(tmp_path_factory, tmp_path): # No base_app_f
     assert style_end != -1
     style_attribute_content = content[start_index + len(text_content_div_start_str):style_end]
     assert "display: none;" in style_attribute_content
+    assert "data-show-on-hover='true'" in content
     assert "hello</p></div>" in content
 
 def test_export_html_rich_text_formatting(tmp_path_factory, tmp_path): # No base_app_fixture
@@ -84,6 +85,7 @@ def test_export_html_rich_text_formatting(tmp_path_factory, tmp_path): # No base
         assert part in style_attribute_content, f"Expected style part '{part}' not found in '{style_attribute_content}'"
     assert 'Formatted Text With Newlines &amp; &lt;HTML&gt;!' in content
     assert 'data-text="Formatted Text' not in content
+    assert "data-show-on-hover='true'" in content
 
 def test_export_html_markdown(tmp_path_factory, tmp_path):
     project_path = tmp_path_factory.mktemp("project_md")
@@ -106,6 +108,22 @@ def test_export_html_markdown(tmp_path_factory, tmp_path):
     content = out_file.read_text()
     assert '<span style=" font-weight' in content
     assert '**bold**' not in content
+
+def test_export_html_always_visible(tmp_path_factory, tmp_path):
+    project_path = tmp_path_factory.mktemp("project_always")
+    os.makedirs(project_path / utils.PROJECT_IMAGES_DIRNAME, exist_ok=True)
+    sample_config = utils.get_default_config()
+    sample_config['project_name'] = "Always"
+    sample_config.setdefault('info_rectangles', []).append({
+        'id': 'r1', 'center_x': 10, 'center_y': 10, 'width': 30, 'height': 20,
+        'text': 'show', 'show_on_hover': False
+    })
+    exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
+    out_file = tmp_path / "export_always.html"
+    assert exporter.export(str(out_file)) is True
+    content = out_file.read_text()
+    assert "data-show-on-hover='false'" in content
+    assert "display: block;" in content
 
 def test_export_to_html_write_error(base_app_fixture, monkeypatch):
     app = base_app_fixture

--- a/tests/test_info_rectangle_item.py
+++ b/tests/test_info_rectangle_item.py
@@ -523,3 +523,12 @@ def test_item_moved_emitted_on_mouse_release(create_item_with_scene):
         mock_super.assert_called_once()
 
     mock_slot.assert_called_once_with(item)
+
+def test_update_appearance_view_mode_visibility(create_item_with_scene):
+    item_hover, _, _ = create_item_with_scene(custom_config={'show_on_hover': True})
+    item_hover.update_appearance(False, True)
+    assert not item_hover.text_item.isVisible()
+
+    item_always, _, _ = create_item_with_scene(custom_config={'show_on_hover': False})
+    item_always.update_appearance(False, True)
+    assert item_always.text_item.isVisible()

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -252,6 +252,7 @@ def test_add_info_rectangle(item_ops, mock_app_instance, monkeypatch):
     expected_width = mock_app_instance.config.get("defaults", {}).get("info_rectangle_text_display", {}).get("box_width", 150)
     assert new_rect_config['width'] == expected_width
     assert new_rect_config['height'] == 50
+    assert new_rect_config['show_on_hover'] is True
     assert new_rect_config['z_index'] == 5
     assert new_rect_config['id'] in mock_app_instance.item_map
     new_item = mock_app_instance.item_map[new_rect_config['id']]


### PR DESCRIPTION
## Summary
- allow configuring info rectangles to display text on hover or always
- include new checkbox in editor UI
- persist `show_on_hover` in config and HTML export
- update HTML exporter logic accordingly
- test new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d892922d0832790e1eced1c575352