### PR TITLE
Add InfoAreaItem with ellipse support

### DIFF
--- a/app.py
+++ b/app.py
@@ -12,7 +12,7 @@ from PyQt5.QtCore import Qt, QTimer, QUrl
 
 from src import utils
 from src.draggable_image_item import DraggableImageItem
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 from src.project_manager_dialog import ProjectManagerDialog
 from src.project_io import ProjectIO
 from src.ui_builder import UIBuilder
@@ -248,9 +248,9 @@ class InfoCanvasApp(QMainWindow):
         if hasattr(self, 'export_html_button'):
             self.export_html_button.setVisible(not is_edit_mode)
         for item_id, graphics_item in self.item_map.items():
-            if isinstance(graphics_item, (DraggableImageItem, InfoRectangleItem)):
+            if isinstance(graphics_item, (DraggableImageItem, InfoAreaItem)):
                 graphics_item.setEnabled(is_edit_mode) 
-                if isinstance(graphics_item, InfoRectangleItem):
+                if isinstance(graphics_item, InfoAreaItem):
                     graphics_item.update_appearance(graphics_item.isSelected(), not is_edit_mode)
             
             if is_edit_mode:
@@ -258,7 +258,7 @@ class InfoCanvasApp(QMainWindow):
                     graphics_item.setCursor(Qt.CursorShape.PointingHandCursor if graphics_item.isEnabled() else Qt.CursorShape.ArrowCursor)
             else:
                 graphics_item.setCursor(Qt.CursorShape.ArrowCursor)
-                if isinstance(graphics_item, InfoRectangleItem):
+                if isinstance(graphics_item, InfoAreaItem):
                     if graphics_item.config_data.get('show_on_hover', True):
                         graphics_item.setToolTip(graphics_item.config_data.get('text', ''))
                     else:
@@ -316,7 +316,7 @@ class InfoCanvasApp(QMainWindow):
             self.img_scale_input.setValue(img_conf.get('scale', 1.0))
             self.img_scale_input.blockSignals(False)
             self.image_properties_widget.setVisible(True)
-        elif isinstance(self.selected_item, InfoRectangleItem):
+        elif isinstance(self.selected_item, InfoAreaItem):
             rect_conf = self.selected_item.config_data
             self.info_rect_text_input.blockSignals(True)
             self.info_rect_width_input.blockSignals(True)
@@ -411,7 +411,7 @@ class InfoCanvasApp(QMainWindow):
             selected_graphics_items = self.scene.selectedItems()
             selected_info_rect_count = 0
             for item in selected_graphics_items:
-                if isinstance(item, InfoRectangleItem):
+                if isinstance(item, InfoAreaItem):
                     selected_info_rect_count += 1
 
             if selected_info_rect_count >= 2: # Changed condition from > 2 to >= 2
@@ -424,12 +424,12 @@ class InfoCanvasApp(QMainWindow):
             self.align_horizontal_button.setVisible(False)
             self.align_vertical_button.setVisible(False)
 
-        if not isinstance(self.selected_item, InfoRectangleItem) or self.current_mode == "view": # Also hide if not an InfoRect or in view mode
+        if not isinstance(self.selected_item, InfoAreaItem) or self.current_mode == "view": # Also hide if not an InfoRect or in view mode
              # This check is a bit redundant if info_rect_properties_widget is already hidden,
              # but ensures buttons are hidden if the main widget for them is hidden.
              self.align_horizontal_button.setVisible(False)
              self.align_vertical_button.setVisible(False)
-             # The rest of the else block for non-InfoRectangleItem selection
+             # The rest of the else block for non-InfoAreaItem selection
              if hasattr(self, 'rect_h_align_combo'): # Check if one of the new controls exists
                 # Find the parent QWidget for the text_format_group to hide it
                 # Assuming rect_props_layout.itemAt(1) is text_format_group (index might change based on final layout)
@@ -440,7 +440,7 @@ class InfoCanvasApp(QMainWindow):
                 # So, specific hiding of text_format_group might not be needed if it's part of info_rect_properties_widget.
                 pass
         # Final check: if the main properties widget is hidden, alignment buttons should also be hidden.
-        # This handles cases where self.selected_item might be None or not an InfoRectangleItem,
+        # This handles cases where self.selected_item might be None or not an InfoAreaItem,
         # leading to info_rect_properties_widget being hidden earlier in this method.
         if not self.info_rect_properties_widget.isVisible():
             self.align_horizontal_button.setVisible(False)
@@ -472,7 +472,7 @@ class InfoCanvasApp(QMainWindow):
 
     def update_selected_rect_text(self):
         """Called when the text in the info_rect_text_input (QTextEdit) changes."""
-        if isinstance(self.selected_item, InfoRectangleItem):
+        if isinstance(self.selected_item, InfoAreaItem):
             rect_conf = self.selected_item.config_data
             new_text = self.info_rect_text_input.toPlainText()
 
@@ -483,7 +483,7 @@ class InfoCanvasApp(QMainWindow):
 
     def update_selected_rect_dimensions(self):
         """Called when width/height spinboxes in the properties panel change."""
-        if isinstance(self.selected_item, InfoRectangleItem):
+        if isinstance(self.selected_item, InfoAreaItem):
             rect_conf = self.selected_item.config_data
             new_width = self.info_rect_width_input.value()
             new_height = self.info_rect_height_input.value()
@@ -494,7 +494,7 @@ class InfoCanvasApp(QMainWindow):
             self.selected_item.properties_changed.emit(self.selected_item)
 
     def update_selected_rect_show_on_hover(self, state):
-        if isinstance(self.selected_item, InfoRectangleItem):
+        if isinstance(self.selected_item, InfoAreaItem):
             rect_conf = self.selected_item.config_data
             rect_conf['show_on_hover'] = bool(state)
             self.selected_item.update_appearance(self.selected_item.isSelected(), self.current_mode == "view")

--- a/src/canvas_manager.py
+++ b/src/canvas_manager.py
@@ -6,7 +6,7 @@ from PyQt5.QtWidgets import QGraphicsScene, QMessageBox, QApplication
 
 from . import utils
 from .draggable_image_item import DraggableImageItem
-from .info_rectangle_item import InfoRectangleItem
+from .info_area_item import InfoAreaItem
 
 
 class CanvasManager(QObject):
@@ -81,7 +81,7 @@ class CanvasManager(QObject):
             app.item_map[img_conf['id']] = item
 
         for rect_conf in config.get('info_rectangles', []):
-            item = InfoRectangleItem(rect_conf)
+            item = InfoAreaItem(rect_conf)
             item.item_selected.connect(self.on_graphics_item_selected)
             item.item_moved.connect(self.on_graphics_item_moved)
             item.properties_changed.connect(self.on_graphics_item_properties_changed)
@@ -120,7 +120,7 @@ class CanvasManager(QObject):
             return
 
         selected_items = self.scene.selectedItems()
-        current_info_rects = [i for i in selected_items if isinstance(i, InfoRectangleItem)]
+        current_info_rects = [i for i in selected_items if isinstance(i, InfoAreaItem)]
         num_selected = len(current_info_rects)
 
         if num_selected == 0:
@@ -133,7 +133,7 @@ class CanvasManager(QObject):
                 app.chronologically_first_selected_item = sorted_rects[0] if sorted_rects else None
 
         for item in self.scene.items():
-            if isinstance(item, InfoRectangleItem):
+            if isinstance(item, InfoAreaItem):
                 item.update_appearance(item.isSelected(), app.current_mode == "view")
 
         if selected_items and app.selected_item not in selected_items:
@@ -153,7 +153,7 @@ class CanvasManager(QObject):
             return
 
         ctrl_pressed = QApplication.keyboardModifiers() & Qt.ControlModifier
-        if ctrl_pressed and isinstance(graphics_item, InfoRectangleItem):
+        if ctrl_pressed and isinstance(graphics_item, InfoAreaItem):
             if graphics_item.isSelected():
                 app.selected_item = graphics_item
             else:
@@ -162,11 +162,11 @@ class CanvasManager(QObject):
             app.update_properties_panel()
             return
 
-        if app.selected_item is graphics_item and isinstance(app.selected_item, InfoRectangleItem):
+        if app.selected_item is graphics_item and isinstance(app.selected_item, InfoAreaItem):
             app.selected_item.update_appearance(True, app.current_mode == "view")
 
         if app.selected_item is not graphics_item:
-            if app.selected_item and isinstance(app.selected_item, InfoRectangleItem):
+            if app.selected_item and isinstance(app.selected_item, InfoAreaItem):
                 app.selected_item.update_appearance(False, app.current_mode == "view")
 
             app.selected_item = graphics_item
@@ -179,10 +179,10 @@ class CanvasManager(QObject):
                 for item_in_scene in self.scene.items():
                     if item_in_scene is not app.selected_item and item_in_scene.isSelected():
                         item_in_scene.setSelected(False)
-                        if isinstance(item_in_scene, InfoRectangleItem):
+                        if isinstance(item_in_scene, InfoAreaItem):
                             item_in_scene.update_appearance(False, app.current_mode == "view")
                 app.selected_item.setSelected(True)
-                if isinstance(app.selected_item, InfoRectangleItem):
+                if isinstance(app.selected_item, InfoAreaItem):
                     app.selected_item.update_appearance(True, app.current_mode == "view")
                 try:
                     self.scene.selectionChanged.connect(self.on_scene_selection_changed)
@@ -196,7 +196,7 @@ class CanvasManager(QObject):
 
     def on_graphics_item_properties_changed(self, graphics_item):
         self.app.save_config()
-        if isinstance(graphics_item, InfoRectangleItem):
+        if isinstance(graphics_item, InfoAreaItem):
             graphics_item.update_geometry_from_config()
             self.app.update_properties_panel()
 
@@ -205,7 +205,7 @@ class CanvasManager(QObject):
         if not self.scene:
             return
         selected_items = self.scene.selectedItems()
-        rects = [i for i in selected_items if isinstance(i, InfoRectangleItem)]
+        rects = [i for i in selected_items if isinstance(i, InfoAreaItem)]
         if len(rects) < 2:
             return
         app = self.app
@@ -227,7 +227,7 @@ class CanvasManager(QObject):
         if not self.scene:
             return
         selected_items = self.scene.selectedItems()
-        rects = [i for i in selected_items if isinstance(i, InfoRectangleItem)]
+        rects = [i for i in selected_items if isinstance(i, InfoAreaItem)]
         if len(rects) < 2:
             return
         app = self.app

--- a/src/info_area_item.py
+++ b/src/info_area_item.py
@@ -7,7 +7,7 @@ from PyQt5.QtGui import QColor, QBrush, QPen, QCursor, QTextOption
 from . import utils
 
 
-class InfoRectangleItem(BaseDraggableItem):
+class InfoAreaItem(BaseDraggableItem):
     item_selected = pyqtSignal(QGraphicsItem)
     properties_changed = pyqtSignal(QGraphicsItem)
 
@@ -35,6 +35,7 @@ class InfoRectangleItem(BaseDraggableItem):
         self._h = self.config_data.get('height', 50)
         self._pen = QPen(Qt.NoPen)
         self._brush = QBrush(Qt.NoBrush)
+        self.shape = rect_config.get('shape', 'rectangle')
 
         # Formatting options
         text_format_defaults = utils.get_default_config()["defaults"]["info_rectangle_text_display"]
@@ -70,7 +71,10 @@ class InfoRectangleItem(BaseDraggableItem):
     def paint(self, painter, option, widget=None):
         painter.setPen(self._pen)
         painter.setBrush(self._brush)
-        painter.drawRect(self.boundingRect())
+        if self.shape == 'ellipse':
+            painter.drawEllipse(self.boundingRect())
+        else:
+            painter.drawRect(self.boundingRect())
 
     def _get_resize_handle_at(self, pos):
         r = self.boundingRect()

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -8,7 +8,7 @@ from PyQt5.QtGui import QImageReader, QPixmap, QTransform
 
 from src import utils
 from src.draggable_image_item import DraggableImageItem
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 
 class ItemOperations:
     def __init__(self, app):
@@ -216,7 +216,7 @@ class ItemOperations:
         if 'info_rectangles' not in self.config: self.config['info_rectangles'] = [] # self.config is app.config
         self.config['info_rectangles'].append(new_rect_config)
 
-        item = InfoRectangleItem(new_rect_config) # Z-value set in item's __init__
+        item = InfoAreaItem(new_rect_config) # Z-value set in item's __init__
 
         # Connect signals to app's CanvasManager handlers
         item.item_selected.connect(self.app.canvas_manager.on_graphics_item_selected)
@@ -233,7 +233,7 @@ class ItemOperations:
         item.setSelected(True)
 
     def delete_selected_info_rect(self):
-        if not isinstance(self.app.selected_item, InfoRectangleItem): # Access app's selected_item
+        if not isinstance(self.app.selected_item, InfoAreaItem): # Access app's selected_item
             QMessageBox.information(self.app, "Delete Info Area", "No info area selected.") # parent is self.app
             return
 
@@ -261,7 +261,7 @@ class ItemOperations:
             self.app.statusBar().showMessage("Clipboard is empty.", 2000)
             return False # Indicate failure
 
-        # Currently, only InfoRectangleItem paste is supported from original logic
+        # Currently, only InfoAreaItem paste is supported from original logic
         if not isinstance(self.app.clipboard_data, dict) or 'text' not in self.app.clipboard_data:
             self.app.statusBar().showMessage("Clipboard data is not for an info area.", 2000)
             return False # Indicate failure
@@ -278,7 +278,7 @@ class ItemOperations:
             self.config['info_rectangles'] = []
         self.config['info_rectangles'].append(new_item_config)
 
-        item = InfoRectangleItem(new_item_config) # Z-value set in item's __init__
+        item = InfoAreaItem(new_item_config) # Z-value set in item's __init__
 
         # Connect signals to app's CanvasManager handlers
         item.item_selected.connect(self.app.canvas_manager.on_graphics_item_selected)
@@ -296,7 +296,7 @@ class ItemOperations:
         return True # Indicate success
 
     def copy_selected_item_to_clipboard(self):
-        if self.app.selected_item and isinstance(self.app.selected_item, InfoRectangleItem) and \
+        if self.app.selected_item and isinstance(self.app.selected_item, InfoAreaItem) and \
            self.app.current_mode == "edit": # Check app's current_mode
             self.app.clipboard_data = copy.deepcopy(self.app.selected_item.config_data) # Use app's clipboard
             self.app.statusBar().showMessage("Info rectangle copied to clipboard.", 2000) # Use app's status bar
@@ -308,7 +308,7 @@ class ItemOperations:
             if isinstance(self.app.selected_item, DraggableImageItem):
                 self.delete_selected_image() # This method now uses self.app.selected_item
                 return True
-            elif isinstance(self.app.selected_item, InfoRectangleItem):
+            elif isinstance(self.app.selected_item, InfoAreaItem):
                 self.delete_selected_info_rect() # This method now uses self.app.selected_item
                 return True
         return False

--- a/src/text_style_manager.py
+++ b/src/text_style_manager.py
@@ -4,7 +4,7 @@ from PyQt5.QtWidgets import QColorDialog, QInputDialog, QMessageBox
 from PyQt5.QtGui import QColor
 
 from src import utils
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 
 class TextStyleManager:
     def __init__(self, app):
@@ -66,7 +66,7 @@ class TextStyleManager:
         self.app.rect_style_combo.blockSignals(False)
 
     def save_current_item_style(self):
-        if not isinstance(self.app.selected_item, InfoRectangleItem):
+        if not isinstance(self.app.selected_item, InfoAreaItem):
             QMessageBox.warning(self.app.main_window if hasattr(self.app, 'main_window') else None, "Save Style", "Please select an Info Area to save its style.")
             return
 
@@ -117,7 +117,7 @@ class TextStyleManager:
         self.load_styles_into_dropdown()
 
         for item_in_map in self.app.item_map.values():
-            if isinstance(item_in_map, InfoRectangleItem):
+            if isinstance(item_in_map, InfoAreaItem):
                 if item_in_map.config_data.get('text_style_ref') == style_name:
                     item_in_map.apply_style(style_object_updated)
 
@@ -135,7 +135,7 @@ class TextStyleManager:
             self.app.statusBar().showMessage(f"Text style '{style_name}' saved and applied.", 2000)
 
     def handle_style_selection(self, style_name):
-        if not isinstance(self.app.selected_item, InfoRectangleItem) or not style_name :
+        if not isinstance(self.app.selected_item, InfoAreaItem) or not style_name :
             return
 
         controls_to_block = []
@@ -190,7 +190,7 @@ class TextStyleManager:
 
 
     def handle_format_change(self, value=None):
-        if isinstance(self.app.selected_item, InfoRectangleItem):
+        if isinstance(self.app.selected_item, InfoAreaItem):
             config = self.app.selected_item.config_data
             default_display_conf = utils.get_default_config()["defaults"]["info_rectangle_text_display"]
 
@@ -227,7 +227,7 @@ class TextStyleManager:
 
 
     def handle_font_color_change(self):
-        if not self.app.selected_item or not isinstance(self.app.selected_item, InfoRectangleItem):
+        if not self.app.selected_item or not isinstance(self.app.selected_item, InfoAreaItem):
             return
 
         item_config = self.app.selected_item.config_data

--- a/src/ui_builder.py
+++ b/src/ui_builder.py
@@ -238,8 +238,8 @@ class UIBuilder:
         rect_width_layout = QHBoxLayout()
         rect_width_layout.addWidget(QLabel("Width (px):"))
         app.info_rect_width_input = QSpinBox()
-        from .info_rectangle_item import InfoRectangleItem
-        app.info_rect_width_input.setRange(InfoRectangleItem.MIN_WIDTH, 2000)
+        from .info_area_item import InfoAreaItem
+        app.info_rect_width_input.setRange(InfoAreaItem.MIN_WIDTH, 2000)
         app.info_rect_width_input.valueChanged.connect(app.update_selected_rect_dimensions)
         rect_width_layout.addWidget(app.info_rect_width_input)
         rect_props_layout.addLayout(rect_width_layout)
@@ -247,7 +247,7 @@ class UIBuilder:
         rect_height_layout = QHBoxLayout()
         rect_height_layout.addWidget(QLabel("Height (px):"))
         app.info_rect_height_input = QSpinBox()
-        app.info_rect_height_input.setRange(InfoRectangleItem.MIN_HEIGHT, 2000)
+        app.info_rect_height_input.setRange(InfoAreaItem.MIN_HEIGHT, 2000)
         app.info_rect_height_input.valueChanged.connect(app.update_selected_rect_dimensions)
         rect_height_layout.addWidget(app.info_rect_height_input)
         rect_props_layout.addLayout(rect_height_layout)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -23,7 +23,7 @@ from app import InfoCanvasApp
 from src import utils # For utils.PROJECTS_BASE_DIR etc.
 from src.project_manager_dialog import ProjectManagerDialog # For mocking
 from src.draggable_image_item import DraggableImageItem # Added
-from src.info_rectangle_item import InfoRectangleItem # Added
+from src.info_area_item import InfoAreaItem # Added
 from src.project_io import ProjectIO
 from src.ui_builder import UIBuilder
 
@@ -317,7 +317,7 @@ def test_on_mode_changed(base_app_fixture, monkeypatch):
     mock_image_item = MagicMock(spec=DraggableImageItem)
     mock_image_item.config_data = {'id': 'img1'}
     mock_image_item.isEnabled.return_value = True
-    mock_info_rect_item = MagicMock(spec=InfoRectangleItem)
+    mock_info_rect_item = MagicMock(spec=InfoAreaItem)
     mock_info_rect_item.config_data = {'id': 'rect1'}
     mock_info_rect_item.isSelected.return_value = False
     mock_info_rect_item.isEnabled.return_value = True

--- a/tests/test_canvas_manager.py
+++ b/tests/test_canvas_manager.py
@@ -1,7 +1,7 @@
 import datetime
 import pytest
 from src.canvas_manager import CanvasManager
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 
 class TestCanvasManagerAlignment:
     def test_horizontal_alignment_logic(self, base_app_fixture, monkeypatch):
@@ -22,7 +22,7 @@ class TestCanvasManagerAlignment:
             rect_id = f"{name_part}_{datetime.datetime.now().timestamp()}_{i}"
             rect_config = {"id": rect_id, "text": name_part, "center_x": cx, "center_y": cy, "width": w, "height": h, "z_index": i}
             app_window.config['info_rectangles'].append(rect_config)
-            item = InfoRectangleItem(rect_config)
+            item = InfoAreaItem(rect_config)
             manager.scene.addItem(item)
             app_window.item_map[rect_id] = item
             items.append(item)
@@ -56,7 +56,7 @@ class TestCanvasManagerAlignment:
             rect_id = f"{name_part}_{datetime.datetime.now().timestamp()}_{i}"
             rect_config = {"id": rect_id, "text": name_part, "center_x": cx, "center_y": cy, "width": w, "height": h, "z_index": i}
             app_window.config['info_rectangles'].append(rect_config)
-            item = InfoRectangleItem(rect_config)
+            item = InfoAreaItem(rect_config)
             manager.scene.addItem(item)
             app_window.item_map[rect_id] = item
             items.append(item)

--- a/tests/test_info_rectangle_item.py
+++ b/tests/test_info_rectangle_item.py
@@ -5,21 +5,21 @@ from PyQt5.QtWidgets import QApplication, QGraphicsScene, QGraphicsView, QGraphi
 from pytestqt.qt_compat import qt_api
 from unittest.mock import Mock, patch
 
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 from src import utils # For default config
 
 # QApplication instance is typically managed by pytest-qt's qapp fixture.
 
 # Constants for resize handles
-TOP_LEFT = InfoRectangleItem.ResizeHandle.TOP_LEFT
-TOP = InfoRectangleItem.ResizeHandle.TOP
-TOP_RIGHT = InfoRectangleItem.ResizeHandle.TOP_RIGHT
-LEFT = InfoRectangleItem.ResizeHandle.LEFT
-RIGHT = InfoRectangleItem.ResizeHandle.RIGHT
-BOTTOM_LEFT = InfoRectangleItem.ResizeHandle.BOTTOM_LEFT
-BOTTOM = InfoRectangleItem.ResizeHandle.BOTTOM
-BOTTOM_RIGHT = InfoRectangleItem.ResizeHandle.BOTTOM_RIGHT
-NONE = InfoRectangleItem.ResizeHandle.NONE
+TOP_LEFT = InfoAreaItem.ResizeHandle.TOP_LEFT
+TOP = InfoAreaItem.ResizeHandle.TOP
+TOP_RIGHT = InfoAreaItem.ResizeHandle.TOP_RIGHT
+LEFT = InfoAreaItem.ResizeHandle.LEFT
+RIGHT = InfoAreaItem.ResizeHandle.RIGHT
+BOTTOM_LEFT = InfoAreaItem.ResizeHandle.BOTTOM_LEFT
+BOTTOM = InfoAreaItem.ResizeHandle.BOTTOM
+BOTTOM_RIGHT = InfoAreaItem.ResizeHandle.BOTTOM_RIGHT
+NONE = InfoAreaItem.ResizeHandle.NONE
 
 
 @pytest.fixture
@@ -49,7 +49,7 @@ def create_item_with_scene(default_text_config_values, qtbot, mock_parent_window
         if custom_config:
             base_config.update(custom_config)
 
-        item = InfoRectangleItem(base_config)
+        item = InfoAreaItem(base_config)
         item.parent_window = parent_window
 
         if add_to_scene:
@@ -88,7 +88,7 @@ def item_fixture(create_item_with_scene):
     (QPointF(50, 49), BOTTOM, 100, 50),
     (QPointF(1, 49), BOTTOM_LEFT, 100, 50),
     (QPointF(1, 25), LEFT, 100, 50),
-    (QPointF(InfoRectangleItem.RESIZE_MARGIN + 5, InfoRectangleItem.RESIZE_MARGIN + 5), NONE, 100, 50),
+    (QPointF(InfoAreaItem.RESIZE_MARGIN + 5, InfoAreaItem.RESIZE_MARGIN + 5), NONE, 100, 50),
     (QPointF(50, 25), NONE, 100, 50),
 ])
 def test_get_all_resize_handles(create_item_with_scene, pos, expected_handle, item_width, item_height):
@@ -128,14 +128,14 @@ def create_mock_hover_event(pos, scene_pos=None):
 
 # --- Test mousePressEvent (Focus on Resize Logic, Direct Call) ---
 @pytest.mark.parametrize("handle_type, press_pos, expected_cursor_shape", [
-    (InfoRectangleItem.ResizeHandle.TOP_LEFT, QPointF(1,1), Qt.SizeFDiagCursor),
-    (InfoRectangleItem.ResizeHandle.TOP, QPointF(50,1), Qt.SizeVerCursor),
-    (InfoRectangleItem.ResizeHandle.TOP_RIGHT, QPointF(99,1), Qt.SizeBDiagCursor),
-    (InfoRectangleItem.ResizeHandle.LEFT, QPointF(1,25), Qt.SizeHorCursor),
-    (InfoRectangleItem.ResizeHandle.RIGHT, QPointF(99,25), Qt.SizeHorCursor),
-    (InfoRectangleItem.ResizeHandle.BOTTOM_LEFT, QPointF(1,49), Qt.SizeBDiagCursor),
-    (InfoRectangleItem.ResizeHandle.BOTTOM, QPointF(50,49), Qt.SizeVerCursor),
-    (InfoRectangleItem.ResizeHandle.BOTTOM_RIGHT, QPointF(99,49), Qt.SizeFDiagCursor),
+    (InfoAreaItem.ResizeHandle.TOP_LEFT, QPointF(1,1), Qt.SizeFDiagCursor),
+    (InfoAreaItem.ResizeHandle.TOP, QPointF(50,1), Qt.SizeVerCursor),
+    (InfoAreaItem.ResizeHandle.TOP_RIGHT, QPointF(99,1), Qt.SizeBDiagCursor),
+    (InfoAreaItem.ResizeHandle.LEFT, QPointF(1,25), Qt.SizeHorCursor),
+    (InfoAreaItem.ResizeHandle.RIGHT, QPointF(99,25), Qt.SizeHorCursor),
+    (InfoAreaItem.ResizeHandle.BOTTOM_LEFT, QPointF(1,49), Qt.SizeBDiagCursor),
+    (InfoAreaItem.ResizeHandle.BOTTOM, QPointF(50,49), Qt.SizeVerCursor),
+    (InfoAreaItem.ResizeHandle.BOTTOM_RIGHT, QPointF(99,49), Qt.SizeFDiagCursor),
 ])
 def test_mouse_press_on_resize_handles(create_item_with_scene, handle_type, press_pos, expected_cursor_shape):
     item, scene, mock_parent_window = create_item_with_scene(custom_config={'width':100, 'height':50})
@@ -147,7 +147,7 @@ def test_mouse_press_on_resize_handles(create_item_with_scene, handle_type, pres
     event_scene_pos = item.mapToScene(press_pos)
     event = create_mock_mouse_event(QGraphicsSceneMouseEvent.GraphicsSceneMousePress, press_pos, scene_pos=event_scene_pos)
 
-    with patch.object(InfoRectangleItem, 'super', create=True) as mock_super:
+    with patch.object(InfoAreaItem, 'super', create=True) as mock_super:
         mock_super.return_value.mousePressEvent = Mock()
         item.mousePressEvent(event)
         if handle_type != NONE:
@@ -265,10 +265,10 @@ def test_mouse_move_resizing_handles(create_item_with_scene, handle_type, initia
     assert event.isAccepted() is True
 
 @pytest.mark.parametrize("handle_type, mouse_delta_scene, expected_dim, expected_val, final_pos_attr, final_pos_val", [
-    (LEFT, QPointF(90,0), "_w", InfoRectangleItem.MIN_WIDTH, "x", 50 + 100 - InfoRectangleItem.MIN_WIDTH),
-    (RIGHT, QPointF(-90,0), "_w", InfoRectangleItem.MIN_WIDTH, "x", 50),
-    (TOP, QPointF(0,40), "_h", InfoRectangleItem.MIN_HEIGHT, "y", 50 + 50 - InfoRectangleItem.MIN_HEIGHT),
-    (BOTTOM, QPointF(0,-40), "_h", InfoRectangleItem.MIN_HEIGHT, "y", 50),
+    (LEFT, QPointF(90,0), "_w", InfoAreaItem.MIN_WIDTH, "x", 50 + 100 - InfoAreaItem.MIN_WIDTH),
+    (RIGHT, QPointF(-90,0), "_w", InfoAreaItem.MIN_WIDTH, "x", 50),
+    (TOP, QPointF(0,40), "_h", InfoAreaItem.MIN_HEIGHT, "y", 50 + 50 - InfoAreaItem.MIN_HEIGHT),
+    (BOTTOM, QPointF(0,-40), "_h", InfoAreaItem.MIN_HEIGHT, "y", 50),
 ])
 def test_mouse_move_resizing_min_constraints(create_item_with_scene, handle_type, mouse_delta_scene, expected_dim, expected_val, final_pos_attr, final_pos_val):
     initial_pos = QPointF(50,50)
@@ -308,7 +308,7 @@ def test_mouse_release_after_resizing(create_item_with_scene):
     QApplication.processEvents()
 
     item._is_resizing = True
-    item._current_resize_handle = InfoRectangleItem.ResizeHandle.BOTTOM_RIGHT
+    item._current_resize_handle = InfoAreaItem.ResizeHandle.BOTTOM_RIGHT
     item._was_movable = bool(item.flags() & QGraphicsItem.ItemIsMovable)
     item.setFlag(QGraphicsItem.ItemIsMovable, False)
 
@@ -413,13 +413,13 @@ def test_update_text_from_config_invalid_font_size(create_item_with_scene, defau
     mock_defaults = {"defaults": {"info_rectangle_text_display": default_text_config_values.copy()}}
     mock_defaults["defaults"]["info_rectangle_text_display"]['font_size'] = "12px"
 
-    with patch('src.info_rectangle_item.utils.get_default_config', return_value=mock_defaults):
+    with patch('src.info_area_item.utils.get_default_config', return_value=mock_defaults):
         item.update_text_from_config()
     assert item.text_item.font().pixelSize() == 12
 
     item.config_data['font_size'] = "another_invalid"
     mock_defaults["defaults"]["info_rectangle_text_display"]['font_size'] = "bad_default_px"
-    with patch('src.info_rectangle_item.utils.get_default_config', return_value=mock_defaults):
+    with patch('src.info_area_item.utils.get_default_config', return_value=mock_defaults):
         item.update_text_from_config()
     assert item.text_item.font().pixelSize() == 14
 

--- a/tests/test_input_handler.py
+++ b/tests/test_input_handler.py
@@ -6,7 +6,7 @@ from PyQt5.QtGui import QKeyEvent
 from PyQt5.QtWidgets import QLineEdit, QSpinBox
 
 from src.input_handler import InputHandler
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 
 
 def create_key_event(key, modifiers=Qt.NoModifier, text=""):
@@ -90,7 +90,7 @@ def test_key_press_shortcuts_wrong_mode(mock_focus_widget, base_app_fixture):
     handler = app.input_handler
     mock_focus_widget.return_value = app.view
     app.current_mode = "view"
-    app.selected_item = MagicMock(spec=InfoRectangleItem)
+    app.selected_item = MagicMock(spec=InfoAreaItem)
     app.clipboard_data = None
     app.item_operations.copy_selected_item_to_clipboard = MagicMock(return_value=False)
     app.item_operations.paste_item_from_clipboard = MagicMock(return_value=False)
@@ -119,7 +119,7 @@ def test_key_press_shortcuts_input_focused(mock_focus_widget, base_app_fixture):
     mock_focus_widget.return_value = MagicMock(spec=['__class__', '__name__'])
     mock_focus_widget.return_value.__class__ = QLineEdit
     app.current_mode = "edit"
-    app.selected_item = MagicMock(spec=InfoRectangleItem)
+    app.selected_item = MagicMock(spec=InfoAreaItem)
     app.clipboard_data = None
     app.item_operations.copy_selected_item_to_clipboard = MagicMock(return_value=False)
     app.item_operations.paste_item_from_clipboard = MagicMock(return_value=False)

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -11,7 +11,7 @@ sys.path.insert(0, project_root)
 from src.item_operations import ItemOperations
 from src import utils
 from src.draggable_image_item import DraggableImageItem
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 from PyQt5.QtWidgets import QApplication, QGraphicsScene, QMainWindow, QFileDialog, QMessageBox
 from PyQt5.QtGui import QPixmap, QImageReader, QTransform, QColor
 from PyQt5.QtCore import Qt, QRectF
@@ -258,7 +258,7 @@ def test_add_info_rectangle(item_ops, mock_app_instance, monkeypatch):
     assert new_rect_config['z_index'] == 5
     assert new_rect_config['id'] in mock_app_instance.item_map
     new_item = mock_app_instance.item_map[new_rect_config['id']]
-    assert isinstance(new_item, InfoRectangleItem)
+    assert isinstance(new_item, InfoAreaItem)
     mock_app_instance.scene.addItem.assert_called_once_with(new_item)
     assert new_item.isSelected()
     mock_app_instance.save_config.assert_called_once()
@@ -272,7 +272,7 @@ def test_delete_selected_info_rect_success(mock_qmessagebox, item_ops, mock_app_
         "width": 100, "height": 50, "z_index": 0
     }
     mock_app_instance.config['info_rectangles'] = [rect_config]
-    mock_selected_item = MagicMock(spec=InfoRectangleItem)
+    mock_selected_item = MagicMock(spec=InfoAreaItem)
     mock_selected_item.config_data = rect_config
     mock_app_instance.selected_item = mock_selected_item
     mock_app_instance.item_map.clear()
@@ -294,7 +294,7 @@ def test_delete_selected_info_rect_user_cancel(mock_qmessagebox, item_ops, mock_
     rect_id_stay = "rect_stay_1"
     rect_config = { "id": rect_id_stay, "text": "Don't Delete" }
     mock_app_instance.config['info_rectangles'] = [rect_config]
-    mock_selected_item = MagicMock(spec=InfoRectangleItem)
+    mock_selected_item = MagicMock(spec=InfoAreaItem)
     mock_selected_item.config_data = rect_config
     mock_app_instance.selected_item = mock_selected_item
     mock_app_instance.item_map = {rect_id_stay: mock_selected_item}
@@ -309,7 +309,7 @@ def test_copy_selected_item_to_clipboard_info_rect_success(item_ops, mock_app_in
     mock_app_instance.current_mode = "edit"
     rect_id = "rect_for_copy"
     rect_config = {"id": rect_id, "text": "Copy Me", "width": 120, "height": 60}
-    mock_selected_item = MagicMock(spec=InfoRectangleItem)
+    mock_selected_item = MagicMock(spec=InfoAreaItem)
     mock_selected_item.config_data = rect_config
     mock_app_instance.selected_item = mock_selected_item
     initial_clipboard_data = mock_app_instance.clipboard_data # Should be None or different
@@ -332,7 +332,7 @@ def test_copy_selected_item_to_clipboard_failure_cases(item_ops, mock_app_instan
     assert mock_app_instance.clipboard_data == "initial_data" # Unchanged
     mock_app_instance.statusBar().showMessage.assert_not_called()
 
-    # Case 2: Item is not an InfoRectangleItem
+    # Case 2: Item is not an InfoAreaItem
     mock_app_instance.selected_item = MagicMock(spec=DraggableImageItem)
     mock_app_instance.selected_item.config_data = {"id": "img1"}
     assert item_ops.copy_selected_item_to_clipboard() is False
@@ -341,7 +341,7 @@ def test_copy_selected_item_to_clipboard_failure_cases(item_ops, mock_app_instan
 
     # Case 3: Not in edit mode
     mock_app_instance.current_mode = "view"
-    mock_selected_item_rect = MagicMock(spec=InfoRectangleItem)
+    mock_selected_item_rect = MagicMock(spec=InfoAreaItem)
     mock_selected_item_rect.config_data = {"id": "rect_view_mode", "text": "Test"}
     mock_app_instance.selected_item = mock_selected_item_rect
     assert item_ops.copy_selected_item_to_clipboard() is False
@@ -368,7 +368,7 @@ def test_paste_item_from_clipboard_info_rect_success(item_ops, mock_app_instance
     assert new_rect_config['z_index'] == 10
     assert new_rect_config['id'] in mock_app_instance.item_map
     new_item = mock_app_instance.item_map[new_rect_config['id']]
-    assert isinstance(new_item, InfoRectangleItem)
+    assert isinstance(new_item, InfoAreaItem)
     mock_app_instance.scene.addItem.assert_called_once_with(new_item)
     assert new_item.isSelected()
     mock_app_instance.save_config.assert_called_once()
@@ -431,7 +431,7 @@ def test_delete_selected_item_on_canvas_image(mock_os_exists, mock_os_remove, mo
 
 @patch('src.item_operations.QMessageBox.question', return_value=QMessageBox.Yes)
 def test_delete_selected_item_on_canvas_info_rect(mock_qmessagebox, item_ops, mock_app_instance):
-    mock_rect_item = MagicMock(spec=InfoRectangleItem)
+    mock_rect_item = MagicMock(spec=InfoAreaItem)
     rect_id_to_delete = "rect_del_canvas"
     rect_config = {"id": rect_id_to_delete, "text": "Test"}
     mock_rect_item.config_data = rect_config

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import QGraphicsScene
 from PyQt5.QtGui import QPixmap
 
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 from src.draggable_image_item import DraggableImageItem
 from src.utils import bring_to_front, send_to_back, bring_forward, send_backward
 
@@ -10,8 +10,8 @@ def create_scene_items():
     scene = QGraphicsScene()
     cfg1 = {'id': 'r1', 'width': 10, 'height': 10, 'center_x': 5, 'center_y': 5, 'text': '', 'z_index': 0}
     cfg2 = {'id': 'r2', 'width': 10, 'height': 10, 'center_x': 15, 'center_y': 5, 'text': '', 'z_index': 1}
-    item1 = InfoRectangleItem(cfg1)
-    item2 = InfoRectangleItem(cfg2)
+    item1 = InfoAreaItem(cfg1)
+    item2 = InfoAreaItem(cfg2)
     scene.addItem(item1)
     scene.addItem(item2)
     return scene, item1, item2
@@ -25,7 +25,7 @@ def create_image_and_rect():
     rect_cfg = {'id': 'r1', 'width': 10, 'height': 10, 'center_x': 5, 'center_y': 5,
                 'text': '', 'z_index': 1}
     img = DraggableImageItem(pix, img_cfg)
-    rect = InfoRectangleItem(rect_cfg)
+    rect = InfoAreaItem(rect_cfg)
     scene.addItem(img)
     scene.addItem(rect)
     return scene, img, rect

--- a/tests/test_text_style_manager.py
+++ b/tests/test_text_style_manager.py
@@ -1,11 +1,11 @@
 import pytest
 from unittest.mock import MagicMock, patch, ANY
 from PyQt5.QtGui import QColor
-from PyQt5.QtWidgets import QComboBox, QPushButton, QMessageBox, QInputDialog, QTextEdit # Added QTextEdit for InfoRectangleItem mock if needed
+from PyQt5.QtWidgets import QComboBox, QPushButton, QMessageBox, QInputDialog, QTextEdit # Added QTextEdit for InfoAreaItem mock if needed
 
-# Assuming utils.py and InfoRectangleItem are in src and path is set up
+# Assuming utils.py and InfoAreaItem are in src and path is set up
 from src import utils
-from src.info_rectangle_item import InfoRectangleItem # Needed for spec and isinstance
+from src.info_area_item import InfoAreaItem # Needed for spec and isinstance
 from src.text_style_manager import TextStyleManager
 
 @pytest.fixture
@@ -35,8 +35,8 @@ def text_style_manager_fixture(monkeypatch):
     mock_app.main_window = None # For dialog parents, can be simple None or MagicMock if specific methods are called
 
     # Selected item setup
-    # Provide a more complete mock for InfoRectangleItem if its methods are called by TextStyleManager
-    mock_selected_item = MagicMock(spec=InfoRectangleItem)
+    # Provide a more complete mock for InfoAreaItem if its methods are called by TextStyleManager
+    mock_selected_item = MagicMock(spec=InfoAreaItem)
     mock_selected_item.config_data = {} # Default empty config
     mock_selected_item.apply_style = MagicMock()
     mock_app.selected_item = mock_selected_item
@@ -191,11 +191,11 @@ def test_manager_style_application_and_updates(text_style_manager_fixture):
     mock_qmessagebox.question.return_value = QMessageBox.Yes # Confirm overwrite
 
     # Mock item map for testing update propagation
-    mock_rect_refing_style = MagicMock(spec=InfoRectangleItem)
+    mock_rect_refing_style = MagicMock(spec=InfoAreaItem)
     mock_rect_refing_style.config_data = {'id': 'rect_ref1', 'text_style_ref': 'NewSavedStyle'}
     mock_rect_refing_style.apply_style = MagicMock()
 
-    mock_rect_not_refing_style = MagicMock(spec=InfoRectangleItem)
+    mock_rect_not_refing_style = MagicMock(spec=InfoAreaItem)
     mock_rect_not_refing_style.config_data = {'id': 'rect_other', 'text_style_ref': 'SomeOtherStyle'}
     mock_rect_not_refing_style.apply_style = MagicMock()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,7 @@ import pytest
 from PyQt5.QtWidgets import QGraphicsScene
 
 from src import utils
-from src.info_rectangle_item import InfoRectangleItem
+from src.info_area_item import InfoAreaItem
 
 
 def test_allowed_file_positive():
@@ -32,8 +32,8 @@ def test_normalize_z_indices(qtbot):
             'text': '', 'z_index': 0}
     cfg2 = {'id': 'r2', 'width': 10, 'height': 10, 'center_x': 15, 'center_y': 5,
             'text': '', 'z_index': 10}
-    item1 = InfoRectangleItem(cfg1)
-    item2 = InfoRectangleItem(cfg2)
+    item1 = InfoAreaItem(cfg1)
+    item2 = InfoAreaItem(cfg2)
     scene.addItem(item1)
     scene.addItem(item2)
     utils.normalize_z_indices(scene)


### PR DESCRIPTION
## Summary
- rename `info_rectangle_item.py` to `info_area_item.py`
- update class name to `InfoAreaItem`
- add `shape` attribute and support ellipse drawing
- update imports and usage across application and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7427129083279c6ae80f83e79d0d