### PR TITLE
Switch to generic info_areas key

### DIFF
--- a/app.py
+++ b/app.py
@@ -468,7 +468,7 @@ class InfoCanvasApp(QMainWindow):
         self.item_operations.delete_selected_image()
 
     def add_info_rectangle(self):
-        self.item_operations.add_info_rectangle()
+        self.item_operations.add_info_area()
 
     def update_selected_rect_text(self):
         """Called when the text in the info_rect_text_input (QTextEdit) changes."""

--- a/src/canvas_manager.py
+++ b/src/canvas_manager.py
@@ -80,7 +80,7 @@ class CanvasManager(QObject):
             self.scene.addItem(item)
             app.item_map[img_conf['id']] = item
 
-        for rect_conf in config.get('info_rectangles', []):
+        for rect_conf in config.get('info_areas', []):
             item = InfoAreaItem(rect_conf)
             item.item_selected.connect(self.on_graphics_item_selected)
             item.item_moved.connect(self.on_graphics_item_moved)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -95,7 +95,7 @@ class HtmlExporter:
             lines.append(
                 f"<img src='{html.escape(src)}' style='position:absolute;left:{left}px;top:{top}px;width:{width}px;height:{height}px;'>"
             )
-        for rect_conf in self.config.get('info_rectangles', []):
+        for rect_conf in self.config.get('info_areas', []):
             rect_width = rect_conf.get('width', 0)
             rect_height = rect_conf.get('height', 0)
             left = rect_conf.get('center_x', 0) - rect_width / 2
@@ -128,6 +128,8 @@ class HtmlExporter:
             h_align = rect_conf.get('horizontal_alignment', self.default_text_config['horizontal_alignment'])
             v_align = rect_conf.get('vertical_alignment', self.default_text_config['vertical_alignment'])
             outer_style = f"position:absolute; left:{left}px; top:{top}px; width:{rect_width}px; height:{rect_height}px; display:flex; box-sizing: border-box;"
+            if rect_conf.get('shape', 'rectangle') == 'ellipse':
+                outer_style += "border-radius:50%;"
             if v_align == "top": outer_style += "align-items:flex-start;"
             elif v_align == "center" or v_align == "middle": outer_style += "align-items:center;"
             elif v_align == "bottom": outer_style += "align-items:flex-end;"

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -197,7 +197,7 @@ class ItemOperations:
             self.app.update_properties_panel() # Call app's method
             self.app.statusBar().showMessage(f"Image '{img_conf['path']}' deleted.", 3000) # app's statusBar
 
-    def add_info_rectangle(self):
+    def add_info_area(self):
         rect_id = f"rect_{datetime.datetime.now().timestamp()}"
         # Access app's config for defaults, then utils if not found
         default_display_conf = self.config.get("defaults", {}).get("info_rectangle_text_display", utils.get_default_config()["defaults"]["info_rectangle_text_display"])
@@ -210,11 +210,12 @@ class ItemOperations:
             "height": 50, # Default height
             "text": "New Information",
             "show_on_hover": True,
+            "shape": "rectangle",
             "z_index": self._get_next_z_index(), # Local method
         }
 
-        if 'info_rectangles' not in self.config: self.config['info_rectangles'] = [] # self.config is app.config
-        self.config['info_rectangles'].append(new_rect_config)
+        if 'info_areas' not in self.config: self.config['info_areas'] = [] # self.config is app.config
+        self.config['info_areas'].append(new_rect_config)
 
         item = InfoAreaItem(new_rect_config) # Z-value set in item's __init__
 
@@ -243,8 +244,8 @@ class ItemOperations:
                                      QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
 
         if reply == QMessageBox.Yes:
-            if rect_conf in self.config.get('info_rectangles', []): # self.config is app.config
-                self.config['info_rectangles'].remove(rect_conf)
+            if rect_conf in self.config.get('info_areas', []): # self.config is app.config
+                self.config['info_areas'].remove(rect_conf)
 
             self.scene.removeItem(self.app.selected_item) # self.scene is app.scene
             if rect_conf.get('id') in self.item_map: del self.item_map[rect_conf['id']] # self.item_map is app.item_map
@@ -274,9 +275,9 @@ class ItemOperations:
         new_item_config['center_y'] = new_item_config.get('center_y', self.scene.height() / 2) + 20 # self.scene is app.scene
         new_item_config['z_index'] = self._get_next_z_index() # Local method
 
-        if 'info_rectangles' not in self.config: # self.config is app.config
-            self.config['info_rectangles'] = []
-        self.config['info_rectangles'].append(new_item_config)
+        if 'info_areas' not in self.config: # self.config is app.config
+            self.config['info_areas'] = []
+        self.config['info_areas'].append(new_item_config)
 
         item = InfoAreaItem(new_item_config) # Z-value set in item's __init__
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -46,7 +46,7 @@ def get_default_config():
             "color": "#DDDDDD"
         },
         "images": [],
-        "info_rectangles": []
+        "info_areas": []
     }
 
 # --- Z-index Management Helpers ---

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -458,7 +458,7 @@ def test_update_selected_rect_text(base_app_fixture, monkeypatch):
     app = base_app_fixture
     rect_id = "rect_to_edit_text"
     initial_text = "Old Text"
-    app.config['info_rectangles'] = [{
+    app.config['info_areas'] = [{
         "id": rect_id, "text": initial_text, "center_x": 10, "center_y": 10,
         "width": 100, "height": 50, "z_index": 1
     }]
@@ -474,7 +474,7 @@ def test_update_selected_rect_text(base_app_fixture, monkeypatch):
     new_text = "This is the new text for the rectangle."
     app.info_rect_text_input.setPlainText(new_text)
     app.update_selected_rect_text()
-    assert app.config['info_rectangles'][0]['text'] == new_text
+    assert app.config['info_areas'][0]['text'] == new_text
     selected_rect_item.set_display_text.assert_called_once_with(new_text)
     app.save_config.assert_called_once()
 
@@ -482,7 +482,7 @@ def test_update_selected_rect_text(base_app_fixture, monkeypatch):
 def test_update_selected_rect_dimensions(base_app_fixture, monkeypatch):
     app = base_app_fixture
     rect_id = "rect_to_resize"
-    app.config['info_rectangles'] = [{
+    app.config['info_areas'] = [{
         "id": rect_id, "text": "Resize me", "center_x": 20, "center_y": 20,
         "width": 100, "height": 50, "z_index": 1
     }]
@@ -506,8 +506,8 @@ def test_update_selected_rect_dimensions(base_app_fixture, monkeypatch):
     app.info_rect_width_input.blockSignals(False)
     app.info_rect_height_input.blockSignals(False)
     app.update_selected_rect_dimensions()
-    assert app.config['info_rectangles'][0]['width'] == new_width
-    assert app.config['info_rectangles'][0]['height'] == new_height
+    assert app.config['info_areas'][0]['width'] == new_width
+    assert app.config['info_areas'][0]['height'] == new_height
     mock_slot_for_properties_changed.assert_called_once_with(selected_rect_item)
     app.save_config.assert_called_once()
     selected_rect_item.update_geometry_from_config.assert_called_once()
@@ -585,7 +585,7 @@ def test_handle_deleted_other_project(base_app_fixture, monkeypatch):
 # Test 'test_font_color_change_updates_item_and_ui' was REMOVED as it's now in test_text_style_manager.py
 # Test 'test_project_load_style_application_and_update' was REMOVED as it's now in test_text_style_manager.py
 
-def test_ctrl_multi_select_info_rectangles(base_app_fixture, monkeypatch):
+def test_ctrl_multi_select_info_areas(base_app_fixture, monkeypatch):
     app = base_app_fixture
     rect1 = {
         'id': 'rect1', 'width': 50, 'height': 40,
@@ -595,7 +595,7 @@ def test_ctrl_multi_select_info_rectangles(base_app_fixture, monkeypatch):
         'id': 'rect2', 'width': 50, 'height': 40,
         'center_x': 150, 'center_y': 50, 'text': 'B'
     }
-    app.config['info_rectangles'] = [rect1, rect2]
+    app.config['info_areas'] = [rect1, rect2]
     app.render_canvas_from_config()
     item1 = app.item_map['rect1']
     item2 = app.item_map['rect2']

--- a/tests/test_canvas_manager.py
+++ b/tests/test_canvas_manager.py
@@ -7,7 +7,7 @@ class TestCanvasManagerAlignment:
     def test_horizontal_alignment_logic(self, base_app_fixture, monkeypatch):
         app_window = base_app_fixture
         manager = CanvasManager(app_window)
-        app_window.config['info_rectangles'] = []
+        app_window.config['info_areas'] = []
         app_window.item_map.clear()
         app_window.scene.clear()
         manager.render_canvas_from_config()
@@ -21,7 +21,7 @@ class TestCanvasManagerAlignment:
         for i, (cx, cy, w, h, name_part) in enumerate(rect_details):
             rect_id = f"{name_part}_{datetime.datetime.now().timestamp()}_{i}"
             rect_config = {"id": rect_id, "text": name_part, "center_x": cx, "center_y": cy, "width": w, "height": h, "z_index": i}
-            app_window.config['info_rectangles'].append(rect_config)
+            app_window.config['info_areas'].append(rect_config)
             item = InfoAreaItem(rect_config)
             manager.scene.addItem(item)
             app_window.item_map[rect_id] = item
@@ -41,7 +41,7 @@ class TestCanvasManagerAlignment:
     def test_vertical_alignment_logic(self, base_app_fixture, monkeypatch):
         app_window = base_app_fixture
         manager = CanvasManager(app_window)
-        app_window.config['info_rectangles'] = []
+        app_window.config['info_areas'] = []
         app_window.item_map.clear()
         app_window.scene.clear()
         manager.render_canvas_from_config()
@@ -55,7 +55,7 @@ class TestCanvasManagerAlignment:
         for i, (cx, cy, w, h, name_part) in enumerate(rect_details):
             rect_id = f"{name_part}_{datetime.datetime.now().timestamp()}_{i}"
             rect_config = {"id": rect_id, "text": name_part, "center_x": cx, "center_y": cy, "width": w, "height": h, "z_index": i}
-            app_window.config['info_rectangles'].append(rect_config)
+            app_window.config['info_areas'].append(rect_config)
             item = InfoAreaItem(rect_config)
             manager.scene.addItem(item)
             app_window.item_map[rect_id] = item

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -15,7 +15,7 @@ def test_export_to_html_writes_file(tmp_path_factory, tmp_path): # No base_app_f
 
     sample_config = utils.get_default_config()
     sample_config['project_name'] = "Test Project HTML"
-    sample_config.setdefault('info_rectangles', []).append({
+    sample_config.setdefault('info_areas', []).append({
         'id': 'r1', 'center_x': 50, 'center_y': 50, 'width': 20, 'height': 20, 'text': 'hello'
     })
 
@@ -59,7 +59,7 @@ def test_export_html_rich_text_formatting(tmp_path_factory, tmp_path): # No base
 
     sample_config = utils.get_default_config()
     sample_config['project_name'] = "Rich Text Test"
-    sample_config.setdefault('info_rectangles', []).append(rect_config_formatted)
+    sample_config.setdefault('info_areas', []).append(rect_config_formatted)
 
     exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
     out_file = tmp_path / "export_formatted.html"
@@ -94,7 +94,7 @@ def test_export_html_markdown(tmp_path_factory, tmp_path):
 
     sample_config = utils.get_default_config()
     sample_config['project_name'] = "MD Test"
-    sample_config.setdefault('info_rectangles', []).append({
+    sample_config.setdefault('info_areas', []).append({
         'id': 'md1', 'center_x': 10, 'center_y': 10, 'width': 50, 'height': 20,
         'text': 'This is **bold**', 'font_color': '#000000'
     })
@@ -115,7 +115,7 @@ def test_export_html_heading_font_sizes(tmp_path_factory, tmp_path):
 
     sample_config = utils.get_default_config()
     sample_config['project_name'] = "Heading Test"
-    sample_config.setdefault('info_rectangles', []).append({
+    sample_config.setdefault('info_areas', []).append({
         'id': 'h1',
         'center_x': 5,
         'center_y': 5,
@@ -138,7 +138,7 @@ def test_export_html_always_visible(tmp_path_factory, tmp_path):
     os.makedirs(project_path / utils.PROJECT_IMAGES_DIRNAME, exist_ok=True)
     sample_config = utils.get_default_config()
     sample_config['project_name'] = "Always"
-    sample_config.setdefault('info_rectangles', []).append({
+    sample_config.setdefault('info_areas', []).append({
         'id': 'r1', 'center_x': 10, 'center_y': 10, 'width': 30, 'height': 20,
         'text': 'show', 'show_on_hover': False
     })
@@ -238,7 +238,7 @@ def test_export_html_contains_drag_script(tmp_path_factory, tmp_path):
     os.makedirs(project_path / utils.PROJECT_IMAGES_DIRNAME, exist_ok=True)
 
     sample_config = utils.get_default_config()
-    sample_config.setdefault('info_rectangles', []).append({
+    sample_config.setdefault('info_areas', []).append({
         'id': 'drag1', 'center_x': 15, 'center_y': 15, 'width': 30, 'height': 20, 'text': 'd'
     })
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -17,7 +17,7 @@ def test_allowed_file_negative():
 
 def test_get_default_config_structure():
     cfg = utils.get_default_config()
-    assert 'background' in cfg and 'images' in cfg and 'info_rectangles' in cfg
+    assert 'background' in cfg and 'images' in cfg and 'info_areas' in cfg
 
 def test_ensure_base_projects_directory_exists(tmp_path, monkeypatch):
     temp_dir = tmp_path / 'projects'


### PR DESCRIPTION
## Summary
- rename `info_rectangles` configuration field to `info_areas`
- provide a default `shape` attribute when creating an info area
- render config through CanvasManager using `info_areas`
- update HtmlExporter for ellipse shapes
- adjust ItemOperations and tests to new terminology

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f78eff9288327aa7579193ce03308