### PR TITLE
Add area shape selection control

### DIFF
--- a/app.py
+++ b/app.py
@@ -324,6 +324,10 @@ class InfoCanvasApp(QMainWindow):
             self.info_rect_text_input.setPlainText(rect_conf.get('text', ''))
             self.info_rect_width_input.setValue(int(rect_conf.get('width', 100)))
             self.info_rect_height_input.setValue(int(rect_conf.get('height', 50)))
+            self.area_shape_combo.blockSignals(True)
+            current_shape = rect_conf.get('shape', 'rectangle')
+            self.area_shape_combo.setCurrentText('Ellipse' if current_shape == 'ellipse' else 'Rectangle')
+            self.area_shape_combo.blockSignals(False)
             self.rect_show_on_hover_checkbox.blockSignals(True)
             self.rect_show_on_hover_checkbox.setChecked(rect_conf.get('show_on_hover', True))
             self.rect_show_on_hover_checkbox.blockSignals(False)
@@ -392,6 +396,7 @@ class InfoCanvasApp(QMainWindow):
             self.rect_v_align_combo.blockSignals(False)
             self.rect_font_size_combo.blockSignals(False)
             self.rect_style_combo.blockSignals(False)
+            self.area_shape_combo.blockSignals(False)
 
             # Update font color button preview
             current_font_color = rect_conf.get('font_color', default_text_config['font_color'])
@@ -499,6 +504,16 @@ class InfoCanvasApp(QMainWindow):
             rect_conf['show_on_hover'] = bool(state)
             self.selected_item.update_appearance(self.selected_item.isSelected(), self.current_mode == "view")
             self.save_config()
+
+    def update_selected_area_shape(self, shape_label):
+        if isinstance(self.selected_item, InfoAreaItem):
+            new_shape = 'ellipse' if shape_label.lower() == 'ellipse' else 'rectangle'
+            rect_conf = self.selected_item.config_data
+            if rect_conf.get('shape') != new_shape:
+                rect_conf['shape'] = new_shape
+                self.selected_item.shape = new_shape
+                self.selected_item.update()
+                self.selected_item.properties_changed.emit(self.selected_item)
 
 
     def delete_selected_info_rect(self):

--- a/src/ui_builder.py
+++ b/src/ui_builder.py
@@ -252,6 +252,14 @@ class UIBuilder:
         rect_height_layout.addWidget(app.info_rect_height_input)
         rect_props_layout.addLayout(rect_height_layout)
 
+        shape_layout = QHBoxLayout()
+        shape_layout.addWidget(QLabel("Area Shape:"))
+        app.area_shape_combo = QComboBox()
+        app.area_shape_combo.addItems(["Rectangle", "Ellipse"])
+        app.area_shape_combo.currentTextChanged.connect(app.update_selected_area_shape)
+        shape_layout.addWidget(app.area_shape_combo)
+        rect_props_layout.addLayout(shape_layout)
+
         app.rect_show_on_hover_checkbox = QCheckBox("Show text on hover only")
         app.rect_show_on_hover_checkbox.stateChanged.connect(app.update_selected_rect_show_on_hover)
         rect_props_layout.addWidget(app.rect_show_on_hover_checkbox)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -513,6 +513,35 @@ def test_update_selected_rect_dimensions(base_app_fixture, monkeypatch):
     selected_rect_item.update_geometry_from_config.assert_called_once()
 
 
+def test_update_selected_area_shape(base_app_fixture, monkeypatch):
+    app = base_app_fixture
+    rect_id = "rect_change_shape"
+    app.config['info_areas'] = [{
+        "id": rect_id, "text": "shape test", "center_x": 20, "center_y": 20,
+        "width": 100, "height": 50, "shape": "rectangle", "z_index": 1
+    }]
+    monkeypatch.setattr(app.scene, 'clear', MagicMock())
+    monkeypatch.setattr(app.scene, 'addItem', MagicMock())
+    app.render_canvas_from_config()
+    selected_rect_item = app.item_map.get(rect_id)
+    assert selected_rect_item is not None
+    app.selected_item = selected_rect_item
+    app.update_properties_panel()
+    mock_slot = MagicMock()
+    selected_rect_item.properties_changed.connect(mock_slot)
+    monkeypatch.setattr(app, 'save_config', MagicMock())
+    monkeypatch.setattr(selected_rect_item, 'update_geometry_from_config', MagicMock())
+
+    app.area_shape_combo.setCurrentText("Ellipse")
+    app.update_selected_area_shape("Ellipse")
+
+    assert app.config['info_areas'][0]['shape'] == 'ellipse'
+    assert selected_rect_item.shape == 'ellipse'
+    mock_slot.assert_called_once_with(selected_rect_item)
+    app.save_config.assert_called_once()
+    selected_rect_item.update_geometry_from_config.assert_called_once()
+
+
 
 
 # --- Tests for Application State Reset --- #


### PR DESCRIPTION
## Summary
- allow users to choose Rectangle or Ellipse for info area shapes
- hook up Area Shape combo box to new handler `update_selected_area_shape`
- redraw shapes when their shape is changed and persist the value
- populate Area Shape dropdown when properties panel updates
- test area shape updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7b7f82408327ba2ff094bb248339