### PR TITLE
Add ellipse shape support in tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -460,7 +460,7 @@ def test_update_selected_rect_text(base_app_fixture, monkeypatch):
     initial_text = "Old Text"
     app.config['info_areas'] = [{
         "id": rect_id, "text": initial_text, "center_x": 10, "center_y": 10,
-        "width": 100, "height": 50, "z_index": 1
+        "width": 100, "height": 50, "z_index": 1, "shape": "rectangle"
     }]
     monkeypatch.setattr(app.scene, 'clear', MagicMock())
     monkeypatch.setattr(app.scene, 'addItem', MagicMock())
@@ -484,7 +484,7 @@ def test_update_selected_rect_dimensions(base_app_fixture, monkeypatch):
     rect_id = "rect_to_resize"
     app.config['info_areas'] = [{
         "id": rect_id, "text": "Resize me", "center_x": 20, "center_y": 20,
-        "width": 100, "height": 50, "z_index": 1
+        "width": 100, "height": 50, "z_index": 1, "shape": "rectangle"
     }]
     monkeypatch.setattr(app.scene, 'clear', MagicMock())
     monkeypatch.setattr(app.scene, 'addItem', MagicMock())
@@ -618,11 +618,11 @@ def test_ctrl_multi_select_info_areas(base_app_fixture, monkeypatch):
     app = base_app_fixture
     rect1 = {
         'id': 'rect1', 'width': 50, 'height': 40,
-        'center_x': 60, 'center_y': 50, 'text': 'A'
+        'center_x': 60, 'center_y': 50, 'text': 'A', 'shape': 'rectangle'
     }
     rect2 = {
         'id': 'rect2', 'width': 50, 'height': 40,
-        'center_x': 150, 'center_y': 50, 'text': 'B'
+        'center_x': 150, 'center_y': 50, 'text': 'B', 'shape': 'rectangle'
     }
     app.config['info_areas'] = [rect1, rect2]
     app.render_canvas_from_config()

--- a/tests/test_canvas_manager.py
+++ b/tests/test_canvas_manager.py
@@ -20,7 +20,10 @@ class TestCanvasManagerAlignment:
         items = []
         for i, (cx, cy, w, h, name_part) in enumerate(rect_details):
             rect_id = f"{name_part}_{datetime.datetime.now().timestamp()}_{i}"
-            rect_config = {"id": rect_id, "text": name_part, "center_x": cx, "center_y": cy, "width": w, "height": h, "z_index": i}
+            rect_config = {
+                "id": rect_id, "text": name_part, "center_x": cx, "center_y": cy,
+                "width": w, "height": h, "z_index": i, "shape": "rectangle"
+            }
             app_window.config['info_areas'].append(rect_config)
             item = InfoAreaItem(rect_config)
             manager.scene.addItem(item)
@@ -54,7 +57,10 @@ class TestCanvasManagerAlignment:
         items = []
         for i, (cx, cy, w, h, name_part) in enumerate(rect_details):
             rect_id = f"{name_part}_{datetime.datetime.now().timestamp()}_{i}"
-            rect_config = {"id": rect_id, "text": name_part, "center_x": cx, "center_y": cy, "width": w, "height": h, "z_index": i}
+            rect_config = {
+                "id": rect_id, "text": name_part, "center_x": cx, "center_y": cy,
+                "width": w, "height": h, "z_index": i, "shape": "rectangle"
+            }
             app_window.config['info_areas'].append(rect_config)
             item = InfoAreaItem(rect_config)
             manager.scene.addItem(item)

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -16,7 +16,8 @@ def test_export_to_html_writes_file(tmp_path_factory, tmp_path): # No base_app_f
     sample_config = utils.get_default_config()
     sample_config['project_name'] = "Test Project HTML"
     sample_config.setdefault('info_areas', []).append({
-        'id': 'r1', 'center_x': 50, 'center_y': 50, 'width': 20, 'height': 20, 'text': 'hello'
+        'id': 'r1', 'center_x': 50, 'center_y': 50, 'width': 20, 'height': 20,
+        'text': 'hello', 'shape': 'rectangle'
     })
 
     exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
@@ -52,6 +53,7 @@ def test_export_html_rich_text_formatting(tmp_path_factory, tmp_path): # No base
         'text': 'Formatted Text\nWith Newlines & <HTML>!', 'font_color': '#FF0000',
         'font_size': '20px', 'background_color': '#FFFF00', 'padding': '10px',
         'horizontal_alignment': 'center', 'vertical_alignment': 'middle',
+        'shape': 'rectangle',
     }
     # Ensure all keys from default_text_config are present if not overridden
     for key, val in default_text_config.items():
@@ -96,7 +98,7 @@ def test_export_html_markdown(tmp_path_factory, tmp_path):
     sample_config['project_name'] = "MD Test"
     sample_config.setdefault('info_areas', []).append({
         'id': 'md1', 'center_x': 10, 'center_y': 10, 'width': 50, 'height': 20,
-        'text': 'This is **bold**', 'font_color': '#000000'
+        'text': 'This is **bold**', 'font_color': '#000000', 'shape': 'rectangle'
     })
 
     exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
@@ -122,7 +124,8 @@ def test_export_html_heading_font_sizes(tmp_path_factory, tmp_path):
         'width': 20,
         'height': 20,
         'text': '# Heading',
-        'font_color': '#000000'
+        'font_color': '#000000',
+        'shape': 'rectangle'
     })
 
     exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
@@ -140,7 +143,7 @@ def test_export_html_always_visible(tmp_path_factory, tmp_path):
     sample_config['project_name'] = "Always"
     sample_config.setdefault('info_areas', []).append({
         'id': 'r1', 'center_x': 10, 'center_y': 10, 'width': 30, 'height': 20,
-        'text': 'show', 'show_on_hover': False
+        'text': 'show', 'show_on_hover': False, 'shape': 'rectangle'
     })
     exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
     out_file = tmp_path / "export_always.html"
@@ -239,7 +242,8 @@ def test_export_html_contains_drag_script(tmp_path_factory, tmp_path):
 
     sample_config = utils.get_default_config()
     sample_config.setdefault('info_areas', []).append({
-        'id': 'drag1', 'center_x': 15, 'center_y': 15, 'width': 30, 'height': 20, 'text': 'd'
+        'id': 'drag1', 'center_x': 15, 'center_y': 15, 'width': 30, 'height': 20,
+        'text': 'd', 'shape': 'rectangle'
     })
 
     exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
@@ -251,6 +255,24 @@ def test_export_html_contains_drag_script(tmp_path_factory, tmp_path):
     assert "requestAnimationFrame(anim)" in content
     assert "animating = true" in content
     assert "cancelAnimationFrame(" in content
+
+
+def test_export_html_ellipse_shape(tmp_path_factory, tmp_path):
+    project_path = tmp_path_factory.mktemp("project_ellipse")
+    os.makedirs(project_path / utils.PROJECT_IMAGES_DIRNAME, exist_ok=True)
+
+    sample_config = utils.get_default_config()
+    sample_config.setdefault('info_areas', []).append({
+        'id': 'e1', 'center_x': 20, 'center_y': 20, 'width': 40, 'height': 30,
+        'text': 'ellipse', 'shape': 'ellipse'
+    })
+
+    exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
+    out_file = tmp_path / "export_ellipse.html"
+
+    assert exporter.export(str(out_file)) is True
+    content = out_file.read_text()
+    assert "border-radius:50%" in content
 
 # Keep other tests like test_export_to_html_write_error,
 # test_export_to_html_uses_dialog, etc., as they are, because they test

--- a/tests/test_info_rectangle_item.py
+++ b/tests/test_info_rectangle_item.py
@@ -41,10 +41,13 @@ def create_item_with_scene(default_text_config_values, qtbot, mock_parent_window
         base_config = {
             'id': 'rect1', 'width': 100, 'height': 50,
             'center_x': 50, 'center_y': 25, 'text': 'hello world',
-            'font_color': default_text_config_values['font_color'], 'font_size': default_text_config_values['font_size'],
-            'background_color': default_text_config_values['background_color'], 'padding': default_text_config_values['padding'],
+            'font_color': default_text_config_values['font_color'],
+            'font_size': default_text_config_values['font_size'],
+            'background_color': default_text_config_values['background_color'],
+            'padding': default_text_config_values['padding'],
             'vertical_alignment': default_text_config_values['vertical_alignment'],
             'horizontal_alignment': default_text_config_values['horizontal_alignment'],
+            'shape': 'rectangle',
         }
         if custom_config:
             base_config.update(custom_config)
@@ -52,6 +55,7 @@ def create_item_with_scene(default_text_config_values, qtbot, mock_parent_window
         item = InfoAreaItem(base_config)
         item.parent_window = parent_window
 
+        scene = None
         if add_to_scene:
             scene = QGraphicsScene()
             scene.setSceneRect(0, 0, 200, 200)
@@ -532,3 +536,11 @@ def test_update_appearance_view_mode_visibility(create_item_with_scene):
     item_always, _, _ = create_item_with_scene(custom_config={'show_on_hover': False})
     item_always.update_appearance(False, True)
     assert item_always.text_item.isVisible()
+
+
+def test_paint_ellipse_calls_correct_method(create_item_with_scene):
+    item, _, _ = create_item_with_scene(custom_config={'shape': 'ellipse'}, add_to_scene=False)
+    painter = Mock()
+    item.paint(painter, None)
+    painter.drawEllipse.assert_called_once()
+    painter.drawRect.assert_not_called()

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -1,15 +1,22 @@
 from PyQt5.QtWidgets import QGraphicsScene
 from PyQt5.QtGui import QPixmap
+import pytest
 
 from src.info_area_item import InfoAreaItem
 from src.draggable_image_item import DraggableImageItem
 from src.utils import bring_to_front, send_to_back, bring_forward, send_backward
 
 
-def create_scene_items():
+def create_scene_items(shape='rectangle'):
     scene = QGraphicsScene()
-    cfg1 = {'id': 'r1', 'width': 10, 'height': 10, 'center_x': 5, 'center_y': 5, 'text': '', 'z_index': 0}
-    cfg2 = {'id': 'r2', 'width': 10, 'height': 10, 'center_x': 15, 'center_y': 5, 'text': '', 'z_index': 1}
+    cfg1 = {
+        'id': 'r1', 'width': 10, 'height': 10, 'center_x': 5, 'center_y': 5,
+        'text': '', 'z_index': 0, 'shape': shape
+    }
+    cfg2 = {
+        'id': 'r2', 'width': 10, 'height': 10, 'center_x': 15, 'center_y': 5,
+        'text': '', 'z_index': 1, 'shape': shape
+    }
     item1 = InfoAreaItem(cfg1)
     item2 = InfoAreaItem(cfg2)
     scene.addItem(item1)
@@ -17,13 +24,17 @@ def create_scene_items():
     return scene, item1, item2
 
 
-def create_image_and_rect():
+def create_image_and_rect(shape='rectangle'):
     scene = QGraphicsScene()
     pix = QPixmap(10, 10)
-    img_cfg = {'id': 'img1', 'original_width': 10, 'original_height': 10, 'scale': 1.0,
-               'center_x': 5, 'center_y': 5, 'z_index': 0}
-    rect_cfg = {'id': 'r1', 'width': 10, 'height': 10, 'center_x': 5, 'center_y': 5,
-                'text': '', 'z_index': 1}
+    img_cfg = {
+        'id': 'img1', 'original_width': 10, 'original_height': 10, 'scale': 1.0,
+        'center_x': 5, 'center_y': 5, 'z_index': 0
+    }
+    rect_cfg = {
+        'id': 'r1', 'width': 10, 'height': 10, 'center_x': 5, 'center_y': 5,
+        'text': '', 'z_index': 1, 'shape': shape
+    }
     img = DraggableImageItem(pix, img_cfg)
     rect = InfoAreaItem(rect_cfg)
     scene.addItem(img)
@@ -31,42 +42,50 @@ def create_image_and_rect():
     return scene, img, rect
 
 
-def test_bring_to_front(qtbot):
-    scene, item1, item2 = create_scene_items()
+
+
+@pytest.mark.parametrize("shape", ["rectangle", "ellipse"])
+def test_bring_to_front(qtbot, shape):
+    scene, item1, item2 = create_scene_items(shape)
     bring_to_front(item1)
     assert item1.zValue() > item2.zValue() and item1.config_data['z_index'] == item1.zValue()
 
 
-def test_send_to_back(qtbot):
-    scene, item1, item2 = create_scene_items()
+@pytest.mark.parametrize("shape", ["rectangle", "ellipse"])
+def test_send_to_back(qtbot, shape):
+    scene, item1, item2 = create_scene_items(shape)
     send_to_back(item2)
     assert item2.zValue() < item1.zValue() and item2.config_data['z_index'] == item2.zValue()
 
 
-def test_bring_forward(qtbot):
-    scene, item1, item2 = create_scene_items()
+@pytest.mark.parametrize("shape", ["rectangle", "ellipse"])
+def test_bring_forward(qtbot, shape):
+    scene, item1, item2 = create_scene_items(shape)
     z_before = item1.zValue()
     bring_forward(item1)
     assert item1.zValue() == z_before + 1 and item1.config_data['z_index'] == item1.zValue()
 
 
-def test_send_backward(qtbot):
-    scene, item1, item2 = create_scene_items()
+@pytest.mark.parametrize("shape", ["rectangle", "ellipse"])
+def test_send_backward(qtbot, shape):
+    scene, item1, item2 = create_scene_items(shape)
     z_before = item2.zValue()
     send_backward(item2)
     assert item2.zValue() == z_before - 1 and item2.config_data['z_index'] == item2.zValue()
 
 
-def test_backward_then_forward(qtbot):
-    scene, item1, item2 = create_scene_items()
+@pytest.mark.parametrize("shape", ["rectangle", "ellipse"])
+def test_backward_then_forward(qtbot, shape):
+    scene, item1, item2 = create_scene_items(shape)
     send_backward(item2)
     assert item2.zValue() < item1.zValue()
     bring_forward(item2)
     assert item2.zValue() > item1.zValue()
 
 
-def test_mixed_items_backward_forward(qtbot):
-    scene, img, rect = create_image_and_rect()
+@pytest.mark.parametrize("shape", ["rectangle", "ellipse"])
+def test_mixed_items_backward_forward(qtbot, shape):
+    scene, img, rect = create_image_and_rect(shape)
     send_backward(rect)
     assert rect.zValue() < img.zValue()
     bring_forward(rect)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -28,10 +28,14 @@ def test_ensure_base_projects_directory_exists(tmp_path, monkeypatch):
 
 def test_normalize_z_indices(qtbot):
     scene = QGraphicsScene()
-    cfg1 = {'id': 'r1', 'width': 10, 'height': 10, 'center_x': 5, 'center_y': 5,
-            'text': '', 'z_index': 0}
-    cfg2 = {'id': 'r2', 'width': 10, 'height': 10, 'center_x': 15, 'center_y': 5,
-            'text': '', 'z_index': 10}
+    cfg1 = {
+        'id': 'r1', 'width': 10, 'height': 10, 'center_x': 5, 'center_y': 5,
+        'text': '', 'z_index': 0, 'shape': 'rectangle'
+    }
+    cfg2 = {
+        'id': 'r2', 'width': 10, 'height': 10, 'center_x': 15, 'center_y': 5,
+        'text': '', 'z_index': 10, 'shape': 'rectangle'
+    }
     item1 = InfoAreaItem(cfg1)
     item2 = InfoAreaItem(cfg2)
     scene.addItem(item1)


### PR DESCRIPTION
## Summary
- add rectangle shape info to configs in tests
- cover ellipse shape in exporter and layering tests
- verify ellipse painting on InfoAreaItem

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7d9fb76c8327b56f990a71512141