### PR TITLE
Fix config persistence when switching projects

### DIFF
--- a/app.py
+++ b/app.py
@@ -87,7 +87,10 @@ class InfoCanvasApp(QMainWindow):
         status_bar = self.statusBar()
         if status_bar is not None:
             status_bar.showMessage("No project loaded. Please create or load a project from the File menu.")
-        
+
+        if hasattr(self, 'item_operations'):
+            self.item_operations.config = self.config
+
         # Force user to select a project again
         QTimer.singleShot(100, self._show_project_manager_dialog_and_handle_outcome)
 
@@ -168,6 +171,8 @@ class InfoCanvasApp(QMainWindow):
                 self.text_style_manager.load_styles_into_dropdown()
             # Reset snapshot history to the loaded project's state
             self.config_snapshot_stack = [copy.deepcopy(self.config)]
+            if hasattr(self, 'item_operations'):
+                self.item_operations.config = self.config
         return success
 
     def _load_config_for_current_project(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -678,3 +678,24 @@ def test_save_config_does_not_duplicate_snapshot(base_app_fixture, monkeypatch):
     assert len(app.config_snapshot_stack) == 1
 
 
+def test_switch_to_project_updates_item_operations_config(base_app_fixture, monkeypatch):
+    app = base_app_fixture
+    old_config = app.config
+    assert app.item_operations.config is old_config
+
+    new_config = {"project_name": "new_proj"}
+
+    def mock_switch(project_name, is_new_project=False):
+        app.project_io.current_project_name = project_name
+        app.project_io.current_project_path = os.path.join(utils.PROJECTS_BASE_DIR, project_name)
+        app.project_io.config = new_config
+        return True
+
+    monkeypatch.setattr(app.project_io, "switch_to_project", mock_switch)
+
+    app._switch_to_project("new_proj")
+
+    assert app.config is new_config
+    assert app.item_operations.config is new_config
+
+


### PR DESCRIPTION
## Summary
- keep ItemOperations config in sync with the current project
- reset ItemOperations config when no project is loaded
- test that switching projects updates ItemOperations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc2ea72648327972affc3cb926ecb