### PR TITLE
Limit info area controls when multi-selecting

### DIFF
--- a/app.py
+++ b/app.py
@@ -376,8 +376,26 @@ class InfoCanvasApp(FramelessWindow):
             return
         self.image_properties_widget.setVisible(False)
         self.info_rect_properties_widget.setVisible(False)
+        self.align_horizontal_button.setVisible(False)
+        self.align_vertical_button.setVisible(False)
+        if hasattr(self, 'info_rect_detail_widget'):
+            self.info_rect_detail_widget.setVisible(False)
+
         if not self.selected_item or self.current_mode == "view":
             return
+
+        selected_info_rect_count = 0
+        if hasattr(self, 'scene') and self.scene:
+            selected_info_rect_count = sum(
+                1 for i in self.scene.selectedItems() if isinstance(i, InfoAreaItem)
+            )
+
+        if selected_info_rect_count >= 2:
+            self.align_horizontal_button.setVisible(True)
+            self.align_vertical_button.setVisible(True)
+            self.info_rect_properties_widget.setVisible(True)
+            return
+
         if isinstance(self.selected_item, DraggableImageItem):
             img_conf = self.selected_item.config_data
             self.img_scale_input.blockSignals(True)
@@ -483,44 +501,11 @@ class InfoCanvasApp(FramelessWindow):
             self.info_rect_text_input.blockSignals(False)
             self.info_rect_width_input.blockSignals(False)
             self.info_rect_height_input.blockSignals(False)
+            if hasattr(self, 'info_rect_detail_widget'):
+                self.info_rect_detail_widget.setVisible(True)
             self.info_rect_properties_widget.setVisible(True)
 
-        # Alignment buttons visibility
-        if hasattr(self, 'scene') and self.scene:
-            selected_graphics_items = self.scene.selectedItems()
-            selected_info_rect_count = 0
-            for item in selected_graphics_items:
-                if isinstance(item, InfoAreaItem):
-                    selected_info_rect_count += 1
-
-            if selected_info_rect_count >= 2: # Changed condition from > 2 to >= 2
-                self.align_horizontal_button.setVisible(True)
-                self.align_vertical_button.setVisible(True)
-            else:
-                self.align_horizontal_button.setVisible(False)
-                self.align_vertical_button.setVisible(False)
-        else:
-            self.align_horizontal_button.setVisible(False)
-            self.align_vertical_button.setVisible(False)
-
-        if not isinstance(self.selected_item, InfoAreaItem) or self.current_mode == "view": # Also hide if not an InfoRect or in view mode
-             # This check is a bit redundant if info_rect_properties_widget is already hidden,
-             # but ensures buttons are hidden if the main widget for them is hidden.
-             self.align_horizontal_button.setVisible(False)
-             self.align_vertical_button.setVisible(False)
-             # The rest of the else block for non-InfoAreaItem selection
-             if hasattr(self, 'rect_h_align_combo'): # Check if one of the new controls exists
-                # Find the parent QWidget for the text_format_group to hide it
-                # Assuming rect_props_layout.itemAt(1) is text_format_group (index might change based on final layout)
-                # A safer way would be to keep a reference to text_format_group if it's complex
-                # For now, let's assume it's the second direct widget in rect_props_layout (after text input)
-                # Or, more simply, hide specific controls or the entire info_rect_properties_widget if no item is selected
-                # The existing logic already hides info_rect_properties_widget if no item is selected or item is not InfoRect.
-                # So, specific hiding of text_format_group might not be needed if it's part of info_rect_properties_widget.
-                pass
         # Final check: if the main properties widget is hidden, alignment buttons should also be hidden.
-        # This handles cases where self.selected_item might be None or not an InfoAreaItem,
-        # leading to info_rect_properties_widget being hidden earlier in this method.
         if not self.info_rect_properties_widget.isVisible():
             self.align_horizontal_button.setVisible(False)
             self.align_vertical_button.setVisible(False)

--- a/src/ui_builder.py
+++ b/src/ui_builder.py
@@ -173,11 +173,15 @@ class UIBuilder:
         app.align_vertical_button.setVisible(False)
         rect_props_layout.addWidget(app.align_vertical_button)
 
+        # Container for individual info area controls so it can be hidden when multiple items are selected
+        app.info_rect_detail_widget = QWidget()
+        detail_layout = QVBoxLayout(app.info_rect_detail_widget)
+
         app.info_rect_text_input = QTextEdit()
         app.info_rect_text_input.setPlaceholderText("Enter information here...")
         app.info_rect_text_input.setFixedHeight(80)
         app.info_rect_text_input.textChanged.connect(app.update_selected_rect_text)
-        rect_props_layout.addWidget(app.info_rect_text_input)
+        detail_layout.addWidget(app.info_rect_text_input)
 
         text_format_group = QWidget()
         text_format_layout = QVBoxLayout(text_format_group)
@@ -242,7 +246,7 @@ class UIBuilder:
         app.rect_save_style_button.clicked.connect(app.text_style_manager.save_current_item_style)
         text_format_layout.addWidget(app.rect_save_style_button)
 
-        rect_props_layout.addWidget(text_format_group)
+        detail_layout.addWidget(text_format_group)
 
         rect_width_layout = QHBoxLayout()
         rect_width_layout.addWidget(QLabel("Width (px):"))
@@ -251,7 +255,7 @@ class UIBuilder:
         app.info_rect_width_input.setRange(InfoAreaItem.MIN_WIDTH, 2000)
         app.info_rect_width_input.valueChanged.connect(app.update_selected_rect_dimensions)
         rect_width_layout.addWidget(app.info_rect_width_input)
-        rect_props_layout.addLayout(rect_width_layout)
+        detail_layout.addLayout(rect_width_layout)
 
         rect_height_layout = QHBoxLayout()
         rect_height_layout.addWidget(QLabel("Height (px):"))
@@ -259,7 +263,7 @@ class UIBuilder:
         app.info_rect_height_input.setRange(InfoAreaItem.MIN_HEIGHT, 2000)
         app.info_rect_height_input.valueChanged.connect(app.update_selected_rect_dimensions)
         rect_height_layout.addWidget(app.info_rect_height_input)
-        rect_props_layout.addLayout(rect_height_layout)
+        detail_layout.addLayout(rect_height_layout)
 
         # Angle control
         angle_layout = QHBoxLayout()
@@ -270,7 +274,7 @@ class UIBuilder:
         app.info_rect_angle_input.setValue(0.0)
         app.info_rect_angle_input.valueChanged.connect(app.update_selected_item_angle)
         angle_layout.addWidget(app.info_rect_angle_input)
-        rect_props_layout.addLayout(angle_layout)
+        detail_layout.addLayout(angle_layout)
 
         shape_layout = QHBoxLayout()
         shape_layout.addWidget(QLabel("Area Shape:"))
@@ -278,16 +282,16 @@ class UIBuilder:
         app.area_shape_combo.addItems(["Rectangle", "Ellipse"])
         app.area_shape_combo.currentTextChanged.connect(app.update_selected_area_shape)
         shape_layout.addWidget(app.area_shape_combo)
-        rect_props_layout.addLayout(shape_layout)
+        detail_layout.addLayout(shape_layout)
 
         app.rect_show_on_hover_checkbox = QCheckBox("Show text on hover only")
         app.rect_show_on_hover_checkbox.stateChanged.connect(app.update_selected_rect_show_on_hover)
-        rect_props_layout.addWidget(app.rect_show_on_hover_checkbox)
+        detail_layout.addWidget(app.rect_show_on_hover_checkbox)
 
         app.delete_info_rect_button = QPushButton("Delete Selected Info Area")
         app.delete_info_rect_button.setStyleSheet("background-color: #dc3545; color: white;")
         app.delete_info_rect_button.clicked.connect(app.delete_selected_info_rect)
-        rect_props_layout.addWidget(app.delete_info_rect_button)
+        detail_layout.addWidget(app.delete_info_rect_button)
 
         rect_layer_layout_line1 = QHBoxLayout()
         app.rect_to_front = QPushButton("Bring to Front")
@@ -310,7 +314,9 @@ class UIBuilder:
         rect_layer_layout_vertical = QVBoxLayout()
         rect_layer_layout_vertical.addLayout(rect_layer_layout_line1)
         rect_layer_layout_vertical.addLayout(rect_layer_layout_line2)
-        rect_props_layout.addLayout(rect_layer_layout_vertical)
+        detail_layout.addLayout(rect_layer_layout_vertical)
+
+        rect_props_layout.addWidget(app.info_rect_detail_widget)
         app.info_rect_properties_widget.setVisible(False)
         rect_layout.addWidget(app.info_rect_properties_widget)
         edit_mode_layout.addWidget(rect_group)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -646,6 +646,24 @@ def test_ctrl_multi_select_info_areas(base_app_fixture, monkeypatch):
     assert app.selected_item is item2, "App's primary selected item should be item2"
 
 
+def test_multi_select_shows_only_align_buttons(base_app_fixture):
+    app = base_app_fixture
+    rect1 = {'id': 'r1', 'width': 50, 'height': 40, 'center_x': 60, 'center_y': 50, 'text': 'A', 'shape': 'rectangle'}
+    rect2 = {'id': 'r2', 'width': 50, 'height': 40, 'center_x': 150, 'center_y': 50, 'text': 'B', 'shape': 'rectangle'}
+    app.config['info_areas'] = [rect1, rect2]
+    app.render_canvas_from_config()
+    item1 = app.item_map['r1']
+    item2 = app.item_map['r2']
+    item1.setSelected(True)
+    item2.setSelected(True)
+    app.canvas_manager.on_scene_selection_changed()
+    app.update_properties_panel()
+    assert app.align_horizontal_button.isVisible()
+    assert app.align_vertical_button.isVisible()
+    assert app.info_rect_properties_widget.isVisible()
+    assert not app.info_rect_detail_widget.isVisible()
+
+
 # --- Tests for Alignment Features --- #
 
 


### PR DESCRIPTION
## Summary
- create `info_rect_detail_widget` container for area-specific controls
- hide detail controls when multiple info areas are selected and show only alignment buttons
- test that only alignment buttons show during multi-select

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535d93394083279a6f18f985f760ff