### PR TITLE
Add line opacity feature

### DIFF
--- a/app.py
+++ b/app.py
@@ -518,10 +518,13 @@ class InfoCanvasApp(FramelessWindow):
             line_conf = self.selected_item.config_data
             self.line_thickness_spin.blockSignals(True)
             self.line_z_index_spin.blockSignals(True)
+            self.line_opacity_spin.blockSignals(True)
             self.line_thickness_spin.setValue(int(line_conf.get('thickness', 2)))
             self.line_z_index_spin.setValue(int(line_conf.get('z_index', 0)))
+            self.line_opacity_spin.setValue(float(line_conf.get('opacity', 1.0)))
             self.line_thickness_spin.blockSignals(False)
             self.line_z_index_spin.blockSignals(False)
+            self.line_opacity_spin.blockSignals(False)
             current_color = line_conf.get('line_color', '#00ffff')
             self.line_color_button.setStyleSheet(f"background-color: {current_color};")
             self.line_properties_widget.setVisible(True)
@@ -647,6 +650,12 @@ class InfoCanvasApp(FramelessWindow):
         if isinstance(self.selected_item, ConnectionLineItem):
             val = self.line_z_index_spin.value()
             self.selected_item.set_z_index(val)
+            self.save_config()
+
+    def update_selected_line_opacity(self):
+        if isinstance(self.selected_item, ConnectionLineItem):
+            val = self.line_opacity_spin.value()
+            self.selected_item.set_opacity(val)
             self.save_config()
 
     def choose_line_color(self):

--- a/src/connection_line_item.py
+++ b/src/connection_line_item.py
@@ -14,6 +14,7 @@ class ConnectionLineItem(QGraphicsObject):
     def __init__(self, line_config, item_map, parent=None):
         super().__init__(parent)
         self.config_data = line_config
+        self.config_data.setdefault('opacity', 1.0)
         self.item_map = item_map
         self.setFlags(QGraphicsItem.ItemIsSelectable)
         self.setZValue(self.config_data.get('z_index', utils.Z_VALUE_INFO_RECT))
@@ -24,6 +25,8 @@ class ConnectionLineItem(QGraphicsObject):
 
     def _update_pen(self):
         color = QColor(self.config_data.get('line_color', '#00ffff'))
+        opacity = float(self.config_data.get('opacity', 1.0))
+        color.setAlphaF(opacity)
         thickness = self.config_data.get('thickness', 2)
         self._pen = QPen(color, thickness)
         self.update()
@@ -63,4 +66,9 @@ class ConnectionLineItem(QGraphicsObject):
     def set_z_index(self, z):
         self.config_data['z_index'] = z
         self.setZValue(z)
+        self.properties_changed.emit(self)
+
+    def set_opacity(self, value):
+        self.config_data['opacity'] = value
+        self._update_pen()
         self.properties_changed.emit(self)

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -167,12 +167,13 @@ class HtmlExporter:
             start_x, start_y, end_x, end_y = utils.compute_connection_points(src, dst)
             color = conn.get('line_color', '#00ffff')
             thickness = conn.get('thickness', 2)
+            opacity = conn.get('opacity', 1.0)
             z = conn.get('z_index', 0)
             line_data = (
                 f"data-source='{conn.get('source')}' data-destination='{conn.get('destination')}'"
             )
             lines.append(
-                f"<svg class='connection-line' {line_data} style='position:absolute;left:0;top:0;width:{bg.get('width',800)}px;height:{bg.get('height',600)}px;pointer-events:none;z-index:{z};'><line x1='{start_x}' y1='{start_y}' x2='{end_x}' y2='{end_y}' stroke='{color}' stroke-width='{thickness}' /></svg>"
+                f"<svg class='connection-line' {line_data} style='position:absolute;left:0;top:0;width:{bg.get('width',800)}px;height:{bg.get('height',600)}px;pointer-events:none;z-index:{z};'><line x1='{start_x}' y1='{start_y}' x2='{end_x}' y2='{end_y}' stroke='{color}' stroke-width='{thickness}' stroke-opacity='{opacity}' /></svg>"
             )
         lines.extend([
 "</div>", "<script>",

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -312,6 +312,7 @@ class ItemOperations:
             "thickness": 2,
             "z_index": self._get_next_z_index(),
             "line_color": "#00ffff",
+            "opacity": 1.0,
         }
         self.config.setdefault('connections', []).append(line_conf)
         from .connection_line_item import ConnectionLineItem

--- a/src/ui_builder.py
+++ b/src/ui_builder.py
@@ -341,6 +341,16 @@ class UIBuilder:
         z_layout.addWidget(app.line_z_index_spin)
         line_props_layout.addLayout(z_layout)
 
+        opacity_layout = QHBoxLayout()
+        opacity_layout.addWidget(QLabel("Opacity:"))
+        app.line_opacity_spin = QDoubleSpinBox()
+        app.line_opacity_spin.setRange(0.0, 1.0)
+        app.line_opacity_spin.setSingleStep(0.05)
+        app.line_opacity_spin.setDecimals(2)
+        app.line_opacity_spin.valueChanged.connect(app.update_selected_line_opacity)
+        opacity_layout.addWidget(app.line_opacity_spin)
+        line_props_layout.addLayout(opacity_layout)
+
         color_layout = QHBoxLayout()
         color_layout.addWidget(QLabel("Line Color:"))
         app.line_color_button = QPushButton("Select Color")

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -302,7 +302,8 @@ def test_export_html_connections(tmp_path_factory, tmp_path):
         {'id': 'a2', 'center_x': 40, 'center_y': 40, 'width': 20, 'height': 20, 'text': 'b', 'shape': 'rectangle'},
     ])
     sample_config.setdefault('connections', []).append({
-        'id': 'c1', 'source': 'a1', 'destination': 'a2', 'thickness': 3, 'z_index': 5, 'line_color': '#ff0000'
+        'id': 'c1', 'source': 'a1', 'destination': 'a2',
+        'thickness': 3, 'z_index': 5, 'line_color': '#ff0000', 'opacity': 0.5
     })
 
     exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
@@ -312,6 +313,7 @@ def test_export_html_connections(tmp_path_factory, tmp_path):
     content = out_file.read_text()
     assert '<svg' in content and 'line' in content
     assert '#ff0000' in content
+    assert "stroke-opacity='0.5'" in content
 
 def test_export_html_lines_follow_drag(tmp_path_factory, tmp_path):
     project_path = tmp_path_factory.mktemp("project_follow")
@@ -332,6 +334,7 @@ def test_export_html_lines_follow_drag(tmp_path_factory, tmp_path):
     assert exporter.export(str(out_file)) is True
     content = out_file.read_text()
     assert 'updateConnectionLines()' in content
+    assert "stroke-opacity='1.0'" in content
 
 # Keep other tests like test_export_to_html_write_error,
 # test_export_to_html_uses_dialog, etc., as they are, because they test


### PR DESCRIPTION
## Summary
- allow storing opacity in `ConnectionLineItem`
- let users edit opacity via GUI
- export opacity as SVG `stroke-opacity`
- test for opacity in exported HTML

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540ca1d2d4832792d4ced03c3a504c