### PR TITLE
Unified opacity configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -441,7 +441,14 @@ class InfoCanvasApp(FramelessWindow):
 
             if hasattr(self, 'rect_area_opacity_spin'):
                 self.rect_area_opacity_spin.blockSignals(True)
-                self.rect_area_opacity_spin.setValue(int(rect_conf.get('fill_alpha', 25)))
+                val = rect_conf.get('fill_alpha', 0.1)
+                try:
+                    val = float(val)
+                except Exception:
+                    val = 0.1
+                if val > 1:
+                    val = val / 255.0
+                self.rect_area_opacity_spin.setValue(val)
                 self.rect_area_opacity_spin.blockSignals(False)
 
             # Update new formatting controls
@@ -691,7 +698,7 @@ class InfoCanvasApp(FramelessWindow):
     def update_selected_area_opacity(self):
         if isinstance(self.selected_item, InfoAreaItem):
             val = self.rect_area_opacity_spin.value()
-            self.selected_item.config_data['fill_alpha'] = val
+            self.selected_item.config_data['fill_alpha'] = float(val)
             self.selected_item.update_appearance(self.selected_item.isSelected(), self.current_mode == "view")
             self.save_config()
 

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -129,7 +129,14 @@ class HtmlExporter:
             v_align = rect_conf.get('vertical_alignment', self.default_text_config['vertical_alignment'])
             outer_style = f"position:absolute; left:{left}px; top:{top}px; width:{rect_width}px; height:{rect_height}px; display:flex; box-sizing: border-box;"
             fill_hex = rect_conf.get('fill_color', utils.get_default_config()["defaults"].get("info_area_appearance", {}).get("fill_color", "#007BFF"))
-            fill_alpha = rect_conf.get('fill_alpha', utils.get_default_config()["defaults"].get("info_area_appearance", {}).get("fill_alpha", 25))
+            fill_alpha = rect_conf.get('fill_alpha', utils.get_default_config()["defaults"].get("info_area_appearance", {}).get("fill_alpha", 0.1))
+            try:
+                fill_alpha = float(fill_alpha)
+            except Exception:
+                fill_alpha = 0.1
+            if fill_alpha > 1:
+                fill_alpha = fill_alpha / 255.0
+            fill_alpha = max(0.0, min(fill_alpha, 1.0))
             rgba_color = utils.hex_to_rgba(fill_hex, fill_alpha)
             outer_style += f"background-color:{rgba_color};"
             if rect_conf.get('shape', 'rectangle') == 'ellipse':

--- a/src/info_area_item.py
+++ b/src/info_area_item.py
@@ -50,7 +50,7 @@ class InfoAreaItem(BaseDraggableItem):
         # Appearance options
         area_defaults = utils.get_default_config()["defaults"].get("info_area_appearance", {})
         self.config_data.setdefault('fill_color', area_defaults.get('fill_color', '#007BFF'))
-        self.config_data.setdefault('fill_alpha', area_defaults.get('fill_alpha', 25))
+        self.config_data.setdefault('fill_alpha', area_defaults.get('fill_alpha', 0.1))
 
         self.setFlags(QGraphicsItem.ItemIsSelectable |
                       QGraphicsItem.ItemIsMovable |
@@ -459,8 +459,15 @@ class InfoAreaItem(BaseDraggableItem):
             self.text_item.setVisible(True)
             pen_color = QColor(self.config_data.get('fill_color', '#007BFF'))
             fill_color = QColor(self.config_data.get('fill_color', '#007BFF'))
-            fill_alpha = int(self.config_data.get('fill_alpha', 25))
-            fill_color.setAlpha(fill_alpha)
+            fill_alpha = self.config_data.get('fill_alpha', 0.1)
+            try:
+                fill_alpha = float(fill_alpha)
+            except Exception:
+                fill_alpha = 0.1
+            if fill_alpha > 1:
+                fill_alpha = fill_alpha / 255.0
+            fill_alpha = max(0.0, min(fill_alpha, 1.0))
+            fill_color.setAlphaF(fill_alpha)
 
             if is_selected:
                 self._pen = QPen(QColor(255, 0, 0, 200), 2, Qt.SolidLine)

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -214,7 +214,7 @@ class ItemOperations:
             "shape": "rectangle",
             "z_index": self._get_next_z_index(), # Local method
             "fill_color": default_area_conf.get("fill_color", "#007BFF"),
-            "fill_alpha": default_area_conf.get("fill_alpha", 25),
+            "fill_alpha": default_area_conf.get("fill_alpha", 0.1),
         }
 
         if 'info_areas' not in self.config: self.config['info_areas'] = [] # self.config is app.config

--- a/src/ui_builder.py
+++ b/src/ui_builder.py
@@ -302,8 +302,10 @@ class UIBuilder:
 
         opacity_layout = QHBoxLayout()
         opacity_layout.addWidget(QLabel("Opacity:"))
-        app.rect_area_opacity_spin = QSpinBox()
-        app.rect_area_opacity_spin.setRange(0, 255)
+        app.rect_area_opacity_spin = QDoubleSpinBox()
+        app.rect_area_opacity_spin.setRange(0.0, 1.0)
+        app.rect_area_opacity_spin.setSingleStep(0.05)
+        app.rect_area_opacity_spin.setDecimals(2)
         app.rect_area_opacity_spin.valueChanged.connect(app.update_selected_area_opacity)
         opacity_layout.addWidget(app.rect_area_opacity_spin)
         detail_layout.addLayout(opacity_layout)

--- a/src/utils.py
+++ b/src/utils.py
@@ -40,7 +40,7 @@ def get_default_config():
             },
             "info_area_appearance": {
                 "fill_color": "#007BFF",
-                "fill_alpha": 25
+                "fill_alpha": 0.1
             }
         },
         "text_styles": [],
@@ -54,8 +54,8 @@ def get_default_config():
         "connections": []
     }
 
-def hex_to_rgba(hex_color, alpha=255):
-    """Converts a hex color and 0-255 alpha to a CSS rgba() string."""
+def hex_to_rgba(hex_color, alpha=1.0):
+    """Converts a hex color and 0-1 alpha to a CSS rgba() string."""
     try:
         hex_color = str(hex_color).lstrip('#')
         r = int(hex_color[0:2], 16)
@@ -64,7 +64,8 @@ def hex_to_rgba(hex_color, alpha=255):
     except Exception:
         r, g, b = 0, 0, 0
     try:
-        alpha_val = max(0, min(int(alpha), 255)) / 255.0
+        alpha_val = float(alpha)
+        alpha_val = max(0.0, min(alpha_val, 1.0))
     except Exception:
         alpha_val = 1.0
     return f"rgba({r},{g},{b},{alpha_val:.3f})"

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -299,7 +299,7 @@ def test_export_html_area_fill_and_opacity(tmp_path_factory, tmp_path):
     sample_config = utils.get_default_config()
     sample_config.setdefault('info_areas', []).append({
         'id': 'fill1', 'center_x': 10, 'center_y': 10, 'width': 30, 'height': 20,
-        'text': 'c', 'shape': 'rectangle', 'fill_color': '#ff0000', 'fill_alpha': 128
+        'text': 'c', 'shape': 'rectangle', 'fill_color': '#ff0000', 'fill_alpha': 0.5
     })
 
     exporter = HtmlExporter(config=sample_config, project_path=str(project_path))
@@ -307,7 +307,7 @@ def test_export_html_area_fill_and_opacity(tmp_path_factory, tmp_path):
 
     assert exporter.export(str(out_file)) is True
     content = out_file.read_text()
-    assert 'background-color:rgba(255,0,0,0.502)' in content
+    assert 'background-color:rgba(255,0,0,0.500)' in content
 
 def test_export_html_connections(tmp_path_factory, tmp_path):
     project_path = tmp_path_factory.mktemp("project_conn")

--- a/tests/test_info_rectangle_item.py
+++ b/tests/test_info_rectangle_item.py
@@ -548,12 +548,12 @@ def test_paint_ellipse_calls_correct_method(create_item_with_scene):
 
 
 def test_update_appearance_custom_fill(create_item_with_scene):
-    cfg = {'fill_color': '#00ff00', 'fill_alpha': 128}
+    cfg = {'fill_color': '#00ff00', 'fill_alpha': 0.5}
     item, _, _ = create_item_with_scene(custom_config=cfg, add_to_scene=False)
     item.update_appearance(False, False)
     color = item._brush.color()
     assert color.name() == '#00ff00'
-    assert color.alpha() == 128
+    assert color.alphaF() == pytest.approx(0.5, abs=1e-2)
 
 
 # --- Tests for Angle Functionality ---


### PR DESCRIPTION
## Summary
- store `fill_alpha` as a float
- use QDoubleSpinBox for info area opacity
- support float opacity when drawing info areas
- export info areas with float opacity
- update tests for float opacity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685410aeae7883278a126739cdd7e4f1