### PR TITLE
Add connection rules

### DIFF
--- a/app.py
+++ b/app.py
@@ -398,11 +398,17 @@ class InfoCanvasApp(FramelessWindow):
             self.align_vertical_button.setVisible(True)
             if selected_info_rect_count == 2:
                 rects = [i for i in self.scene.selectedItems() if isinstance(i, InfoAreaItem)]
-                if len(rects) == 2 and self.connection_exists(rects[0].config_data.get('id'), rects[1].config_data.get('id')):
-                    self.connect_rects_button.setText("Disconnect Areas")
-                else:
-                    self.connect_rects_button.setText("Connect Selected Areas")
-                self.connect_rects_button.setVisible(True)
+                if len(rects) == 2:
+                    id1 = rects[0].config_data.get('id')
+                    id2 = rects[1].config_data.get('id')
+                    if self.connection_exists(id1, id2):
+                        self.connect_rects_button.setText("Disconnect Areas")
+                        self.connect_rects_button.setVisible(True)
+                    elif self.item_operations._connection_allowed(id1, id2):
+                        self.connect_rects_button.setText("Connect Selected Areas")
+                        self.connect_rects_button.setVisible(True)
+                    else:
+                        self.connect_rects_button.setVisible(False)
             self.info_rect_properties_widget.setVisible(True)
             return
 

--- a/src/item_operations.py
+++ b/src/item_operations.py
@@ -379,7 +379,7 @@ class ItemOperations:
 
     def _unconnected_to_connected_allowed(self, unconn_id, conn_id):
         conn_count = self._connection_count(conn_id)
-        if conn_count > 2:
+        if conn_count >= 2:
             return True
         if conn_count == 1:
             connected = self._connected_areas(conn_id)

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -664,6 +664,42 @@ def test_multi_select_shows_only_align_buttons(base_app_fixture):
     assert not app.info_rect_detail_widget.isVisible()
 
 
+def test_connect_button_visibility_based_on_rules(base_app_fixture):
+    app = base_app_fixture
+    rect1 = {'id': 'r1', 'width': 50, 'height': 40, 'center_x': 60, 'center_y': 50, 'text': 'A', 'shape': 'rectangle'}
+    rect2 = {'id': 'r2', 'width': 50, 'height': 40, 'center_x': 150, 'center_y': 50, 'text': 'B', 'shape': 'rectangle'}
+    rect3 = {'id': 'r3', 'width': 50, 'height': 40, 'center_x': 240, 'center_y': 50, 'text': 'C', 'shape': 'rectangle'}
+    rect4 = {'id': 'r4', 'width': 50, 'height': 40, 'center_x': 330, 'center_y': 50, 'text': 'D', 'shape': 'rectangle'}
+
+    app.config['info_areas'] = [rect1, rect2, rect3, rect4]
+    app.config['connections'] = [
+        {'id': 'c1', 'source': 'r2', 'destination': 'r3'},
+        {'id': 'c2', 'source': 'r3', 'destination': 'r4'},
+    ]
+    app.render_canvas_from_config()
+    item1 = app.item_map['r1']
+    item2 = app.item_map['r2']
+    item1.setSelected(True)
+    item2.setSelected(True)
+    app.canvas_manager.on_scene_selection_changed()
+    app.update_properties_panel()
+    assert not app.connect_rects_button.isVisible()
+
+    app.config['connections'] = [
+        {'id': 'c1', 'source': 'r2', 'destination': 'r3'},
+        {'id': 'c2', 'source': 'r2', 'destination': 'r4'},
+    ]
+    app.render_canvas_from_config()
+    item1 = app.item_map['r1']
+    item2 = app.item_map['r2']
+    item1.setSelected(True)
+    item2.setSelected(True)
+    app.canvas_manager.on_scene_selection_changed()
+    app.update_properties_panel()
+    assert app.connect_rects_button.isVisible()
+    assert app.connect_rects_button.text() == "Connect Selected Areas"
+
+
 # --- Tests for Alignment Features --- #
 
 

--- a/tests/test_item_operations.py
+++ b/tests/test_item_operations.py
@@ -483,7 +483,7 @@ def test_connection_allowed_rules(item_ops):
         {'id': 'c1', 'source': 'b', 'destination': 'x'},
         {'id': 'c2', 'source': 'b', 'destination': 'y'},
     ]
-    assert item_ops._connection_allowed('a', 'b') is False
+    assert item_ops._connection_allowed('a', 'b') is True
 
     cfg['connections'] = [
         {'id': 'c1', 'source': 'b', 'destination': 'c'},


### PR DESCRIPTION
## Summary
- enforce new rules when connecting info areas
- add helper methods to check connection counts
- test connection rules and connect operation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541b63bde083278564d7b574dd00fa