### PR TITLE
Update hover info area behavior

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -158,8 +158,9 @@ class HtmlExporter:
             ]
             current_inner_style = "".join(inner_style_list)
             show_on_hover = rect_conf.get('show_on_hover', True)
-            display_style = 'none' if show_on_hover else 'block'
-            text_content_div_style = current_inner_style + f" display: {display_style};"
+            if show_on_hover:
+                outer_style += "opacity:0;"
+            text_content_div_style = current_inner_style
             data_attr = f"data-show-on-hover='{str(show_on_hover).lower()}'"
             extra_data = (
                 f"data-id='{rect_conf.get('id')}' "
@@ -215,11 +216,9 @@ class HtmlExporter:
 "  });",
 "}",
 "document.querySelectorAll('.hotspot.info-rectangle-export').forEach(function(h){",
-"  var textContentDiv=h.querySelector('.text-content');",
-"  if(!textContentDiv) return;",
 "  if(h.dataset.showOnHover!=='false'){",
-"    h.addEventListener('mouseenter',function(){textContentDiv.style.display='block';});",
-"    h.addEventListener('mouseleave',function(){textContentDiv.style.display='none';});",
+"    h.addEventListener('mouseenter',function(){h.style.opacity='1';});",
+"    h.addEventListener('mouseleave',function(){h.style.opacity='0';});",
 "  }",
 "  var origLeft=h.offsetLeft;",
 "  var origTop=h.offsetTop;",

--- a/src/ui_builder.py
+++ b/src/ui_builder.py
@@ -284,7 +284,7 @@ class UIBuilder:
         shape_layout.addWidget(app.area_shape_combo)
         detail_layout.addLayout(shape_layout)
 
-        app.rect_show_on_hover_checkbox = QCheckBox("Show text on hover only")
+        app.rect_show_on_hover_checkbox = QCheckBox("Show info area on hover only")
         app.rect_show_on_hover_checkbox.stateChanged.connect(app.update_selected_rect_show_on_hover)
         detail_layout.addWidget(app.rect_show_on_hover_checkbox)
 

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -31,14 +31,15 @@ def test_export_to_html_writes_file(tmp_path_factory, tmp_path): # No base_app_f
     assert '<html>' in content
     assert 'hello' in content
     assert 'hotspot' in content
-    assert '.text-content' in content
-    text_content_div_start_str = "<div class='text-content' style='"
-    start_index = content.find(text_content_div_start_str)
+    assert "class='text-content'" in content
+    hotspot_start_str = "<div class='hotspot info-rectangle-export'"
+    start_index = content.find(hotspot_start_str)
     assert start_index != -1
-    style_end = content.find("'>", start_index)
-    assert style_end != -1
-    style_attribute_content = content[start_index + len(text_content_div_start_str):style_end]
-    assert "display: none;" in style_attribute_content
+    style_attr_start = content.find("style='", start_index)
+    assert style_attr_start != -1
+    style_end = content.find("'", style_attr_start + 7)
+    style_attribute_content = content[style_attr_start + 7:style_end]
+    assert "opacity:0;" in style_attribute_content
     assert "data-show-on-hover='true'" in content
     assert "hello</p></div>" in content
 
@@ -75,7 +76,7 @@ def test_export_html_rich_text_formatting(tmp_path_factory, tmp_path): # No base
     assert 'align-items:center;' in content
     expected_inner_style_parts = [
         'color:#FF0000;', 'font-size:20px;', 'background-color:transparent;',
-        'padding:10px;', 'text-align:center;', 'display: none;'
+        'padding:10px;', 'text-align:center;'
     ]
     text_content_div_start_str = "<div class='text-content' style='"
     start_index = content.find(text_content_div_start_str)
@@ -85,6 +86,14 @@ def test_export_html_rich_text_formatting(tmp_path_factory, tmp_path): # No base
     style_attribute_content = content[start_index + len(text_content_div_start_str):style_end]
     for part in expected_inner_style_parts:
         assert part in style_attribute_content, f"Expected style part '{part}' not found in '{style_attribute_content}'"
+    hotspot_start_str = "<div class='hotspot info-rectangle-export'"
+    start_index = content.find(hotspot_start_str)
+    assert start_index != -1
+    style_attr_start = content.find("style='", start_index)
+    assert style_attr_start != -1
+    style_end = content.find("'", style_attr_start + 7)
+    outer_style = content[style_attr_start + 7:style_end]
+    assert "opacity:0;" in outer_style
     assert 'Formatted Text With Newlines &amp; &lt;HTML&gt;!' in content
     assert 'data-text="Formatted Text' not in content
     assert "data-show-on-hover='true'" in content
@@ -150,7 +159,7 @@ def test_export_html_always_visible(tmp_path_factory, tmp_path):
     assert exporter.export(str(out_file)) is True
     content = out_file.read_text()
     assert "data-show-on-hover='false'" in content
-    assert "display: block;" in content
+    assert "opacity:0;" not in content
 
 def test_export_to_html_write_error(base_app_fixture, monkeypatch):
     app = base_app_fixture


### PR DESCRIPTION
## Summary
- rename hover-only UI text to "Show info area on hover only"
- adjust HtmlExporter to hide the entire info area until hovered
- update exported JavaScript accordingly
- update tests to match new hover behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685424d78d508327977291f3a8506515