### PR TITLE
Fix hover connected visibility in HTML export

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -161,6 +161,8 @@ class HtmlExporter:
             hover_connected = rect_conf.get('show_on_hover_connected', False)
             if show_on_hover or hover_connected:
                 outer_style += "opacity:0;"
+            if hover_connected and not show_on_hover:
+                outer_style += "pointer-events:none;"
             text_content_div_style = current_inner_style
             data_attr = (
                 f"data-show-on-hover='{str(show_on_hover).lower()}' "
@@ -237,8 +239,9 @@ class HtmlExporter:
 "  if(h.dataset.showOnHoverConnected==='true' && h.dataset.hoverTarget){",
 "    var t=document.querySelector('.info-rectangle-export[data-id="'+h.dataset.hoverTarget+'"]');",
 "    if(t){",
-"      t.addEventListener('mouseenter',function(){h.style.opacity='1';});",
-"      t.addEventListener('mouseleave',function(){h.style.opacity='0';});",
+"      h.style.pointerEvents='none';",
+"      t.addEventListener('mouseenter',function(){h.style.opacity='1';h.style.pointerEvents='auto';});",
+"      t.addEventListener('mouseleave',function(){h.style.opacity='0';h.style.pointerEvents='none';});",
 "    }",
 "  }else if(h.dataset.showOnHover!=='false'){",
 "    h.addEventListener('mouseenter',function(){h.style.opacity='1';});",

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -387,6 +387,11 @@ def test_export_html_hover_connected(tmp_path_factory, tmp_path):
     content = out_file.read_text()
     assert "data-show-on-hover-connected='true'" in content
     assert "data-hover-target='dst'" in content
+    src_index = content.find("data-id='src'")
+    style_start = content.find("style='", src_index)
+    style_end = content.find("'", style_start + 7)
+    src_style = content[style_start + 7:style_end]
+    assert "pointer-events:none" in src_style
 
 # Keep other tests like test_export_to_html_write_error,
 # test_export_to_html_uses_dialog, etc., as they are, because they test


### PR DESCRIPTION
## Summary
- hide inactive hover-connected areas from intercepting pointer events
- enable showing/hiding these areas with pointer-events toggled in exported HTML
- test pointer-events disabled for hover-connected areas

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854317b225c8327bde145b81fef1c6e