### PR TITLE
Add toggle to reveal all info areas in exported HTML

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -220,8 +220,18 @@ class HtmlExporter:
             lines.append(
                 f"<svg class='connection-line' {line_data} style='{initial_line_style}'><line x1='{start_x}' y1='{start_y}' x2='{end_x}' y2='{end_y}' stroke='{color}' stroke-width='{thickness}' /></svg>"
             )
+        lines.append(
+            "<button id='toggle-all-info' style='position:absolute;right:10px;bottom:10px;z-index:1000;'>Show All Info</button>"
+        )
         lines.extend([
 "</div>", "<script>",
+"var showAllInfo=false;",
+"document.getElementById('toggle-all-info').addEventListener('click',function(){",
+"  showAllInfo=!showAllInfo;",
+"  this.textContent=showAllInfo?'Hide All Info':'Show All Info';",
+"  updateAllVisibilities();",
+"  updateConnectionLines();",
+"});",
 "function computeRectBoundaryPoint(rect,target){",
 "  var cx=parseFloat(rect.style.left)+rect.offsetWidth/2;",
 "  var cy=parseFloat(rect.style.top)+rect.offsetHeight/2;",
@@ -249,6 +259,11 @@ class HtmlExporter:
 "  });",
 "}",
 "function updateAllVisibilities(currentlyHoveredItemId = null) {",
+"    if(showAllInfo){",
+"        document.querySelectorAll('.hotspot.info-rectangle-export').forEach(h=>h.style.opacity='1');",
+"        document.querySelectorAll('.connection-line').forEach(line=>line.style.opacity=line.dataset.originalOpacity);",
+"        return;",
+"    }",
 "    // First, reset all hover-dependent items to hidden (opacity 0)",
 "    document.querySelectorAll('.hotspot.info-rectangle-export').forEach(h => {",
 "        // An item is hover-dependent if show_on_hover is true, OR if show_on_hover is false but show_on_hover_connected is true",

--- a/tests/test_export_html.py
+++ b/tests/test_export_html.py
@@ -629,3 +629,17 @@ def test_export_html_connection_line_respects_own_opacity_if_not_hidden_by_hover
 
     line_svg_regex = rf"<svg class='connection-line' data-source='ia1' data-destination='ia2' {expected_line_data_attr} style='{initial_expected_style}'>"
     assert re.search(line_svg_regex, content), f"SVG line for conn1 not found with correct data-original-opacity and initial style. Searched for: {line_svg_regex}"
+
+
+def test_export_html_contains_toggle_button(tmp_path_factory, tmp_path):
+    project_path = tmp_path_factory.mktemp("project_toggle")
+    os.makedirs(project_path / utils.PROJECT_IMAGES_DIRNAME, exist_ok=True)
+
+    config = utils.get_default_config()
+    exporter = HtmlExporter(config=config, project_path=str(project_path))
+    out_file = tmp_path / "toggle.html"
+
+    assert exporter.export(str(out_file)) is True
+    content = out_file.read_text()
+    assert "<button id='toggle-all-info'" in content
+    assert "var showAllInfo" in content


### PR DESCRIPTION
## Summary
- add "Show All Info" button to exported HTML
- implement JS logic to toggle visibility of hotspots and connections
- test for presence of new toggle in exported HTML

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bs4')*

------
https://chatgpt.com/codex/tasks/task_e_685860d4e8f88327a3aea16fa4ef6bbe